### PR TITLE
fix: scrollbar broken style issue on frontend view

### DIFF
--- a/assets/less/style.less
+++ b/assets/less/style.less
@@ -1158,19 +1158,19 @@ div:focus, span:focus, button:focus, input:focus {
 }
 
 #vue-frontend-app {
-    /* Scrollbar */
+    scrollbar-color: rgba(0,0,0,0.3) rgba(0,0,0,0.07);
+    scrollbar-width: thin !important;
+
     ::-webkit-scrollbar {
         width: 10px;
     }
 
-    /* Scrollbar Track */
     ::-webkit-scrollbar-track {
         -webkit-box-shadow: inset 0 0 1px rgba(0,0,0,0.3);
         -webkit-border-radius: 5px;
         border-radius: 5px;
     }
 
-    /* Scrollbar Handle */
     ::-webkit-scrollbar-thumb {
         -webkit-border-radius: 5px;
         border-radius: 5px;

--- a/assets/less/style.less
+++ b/assets/less/style.less
@@ -1157,3 +1157,27 @@ div:focus, span:focus, button:focus, input:focus {
     }
 }
 
+#vue-frontend-app {
+    /* Scrollbar */
+    ::-webkit-scrollbar {
+        width: 10px;
+    }
+
+    /* Scrollbar Track */
+    ::-webkit-scrollbar-track {
+        -webkit-box-shadow: inset 0 0 1px rgba(0,0,0,0.3);
+        -webkit-border-radius: 5px;
+        border-radius: 5px;
+    }
+
+    /* Scrollbar Handle */
+    ::-webkit-scrollbar-thumb {
+        -webkit-border-radius: 5px;
+        border-radius: 5px;
+        background: rgba(0,0,0,0.07);
+    }
+
+    ::-webkit-scrollbar-thumb:window-inactive {
+        background: rgba(0,0,0,0.07);
+    }
+}


### PR DESCRIPTION
Previously, scrollbars were looking awkward on frontend view from `Windows` based browsers.

Now, fixed the issue by modifying the styles of scrollbars on `Windows` based browsers.