### PR TITLE
fix: customer selection dropdown selecting wrong customer by pressing enter key on frontend

### DIFF
--- a/assets/src/frontend/components/CustomerSearch.vue
+++ b/assets/src/frontend/components/CustomerSearch.vue
@@ -28,7 +28,7 @@
             <span class="add-new-customer flaticon-add" @click.prevent="addNewCustomer()"></span>
             <div class="search-result" v-show="showCustomerResults">
                 <div v-if="customers.length">
-                    <keyboard-control :listLength="customers.length" @selected="selectedHandler" @key-down="onKeyDown" @key-up="onKeyUp">
+                    <keyboard-control :listLength="customers.length" @key-down="onKeyDown" @key-up="onKeyUp">
                         <template slot-scope="{selectedIndex}">
                             <li v-for="(customer, index) in customers" class="customer-search-item" :class="{'selected': index === selectedIndex}" :key="index">
                                 <a href="#" class="wepos-clearfix" @click="selectCustomer( customer )">
@@ -244,10 +244,6 @@ export default {
         },
         addNewCustomer() {
             this.showNewCustomerModal = true;
-        },
-        selectedHandler(selectedIndex) {
-            var selectedCustomer = this.customers[selectedIndex];
-            this.selectCustomer( selectedCustomer );
         },
         onKeyDown() {
             jQuery('.customer-search-item.selected').next().children('a').focus();

--- a/assets/src/frontend/components/KeyboardControl.vue
+++ b/assets/src/frontend/components/KeyboardControl.vue
@@ -30,13 +30,7 @@ export default {
       } else if (key === 40 || key === 9) {
         this.handleKeyDown(e);
         this.$emit('key-down');
-      } else if (key === 13) {
-        this.handleEnter(e);
       }
-    },
-    handleEnter(e) {
-      e.preventDefault();
-      this.$emit("selected", this.selectedIndex);
     },
     handleKeyUp(e) {
       e.preventDefault();

--- a/assets/src/frontend/components/ProductSearch.vue
+++ b/assets/src/frontend/components/ProductSearch.vue
@@ -10,7 +10,7 @@
             </div>
             <div class="search-result" v-show="showResults && mode=='product'">
                 <div v-if="searchableProduct.length">
-                    <keyboard-control :listLength="searchableProduct.length" @selected="selectedHandler" @key-down="onKeyDown" @key-up="onKeyUp">
+                    <keyboard-control :listLength="searchableProduct.length" @key-down="onKeyDown" @key-up="onKeyUp">
                         <template slot-scope="{selectedIndex}">
                             <li v-for="(product, index) in searchableProduct" class="product-search-item" :class="{'selected': index === selectedIndex}" :key="index">
                                 <template v-if="product.type == 'simple'">
@@ -153,15 +153,6 @@ export default {
             this.showVariationModal = false;
             this.changeMode('scan');
             this.$refs.productSearch.blur();
-        },
-
-        selectedHandler(selectedIndex) {
-            var selectedProduct = this.searchableProduct[selectedIndex];
-            if ( selectedProduct.type =='simple' ) {
-                this.addToCartAction( selectedProduct );
-            } else {
-                this.selectVariation( selectedProduct );
-            }
         },
 
         onKeyDown() {


### PR DESCRIPTION
Previously, customer selection dropdown was selecting wrong customer by pressing enter/return key on frontend. Before searching registered customer names, there is no issue found. The issue only found after closing the customer names dropdown by searching and selecting a customer.

Also, pressing enter/return key results product addition to the cart, even the product search dropdown closed.

Now, fixed the above 2 issues with this PR.

Fixes: #107 
Fixes: #109 