### PR TITLE
enhance: Added all decimal separator support as per wooCommerce settings to put a discount or adding a fee in POS settings

### DIFF
--- a/assets/src/frontend/components/FeeKeypad.vue
+++ b/assets/src/frontend/components/FeeKeypad.vue
@@ -78,15 +78,14 @@ export default {
             this.displayValue='';
         },
         change(value){
-            if ( !isNaN(value) ) {
-                this.displayValue = value;
-                this.input = this.displayValue;
-            } else {
-                this.input = this.displayValue;
-                if ( this.displayValue == '' ) {
-                    this.input = '';
-                }
+            let displayValue  = value.replace( ".", wepos.currency_format_decimal_sep );
+            let originalValue = value.replace( wepos.currency_format_decimal_sep, "." );
+
+            if ( ! isNaN( originalValue ) ) {
+                this.displayValue = displayValue;
             }
+
+            this.input = originalValue;
 
             jQuery( this.$refs.feeinput ).focus();
 

--- a/assets/src/frontend/components/FeeKeypad.vue
+++ b/assets/src/frontend/components/FeeKeypad.vue
@@ -4,9 +4,9 @@
             <a href="#" @click="showFeeKeypad">{{ __( 'Add', 'wepos' ) }} {{ name }}</a>
             <template slot="popover">
                 <form>
-                    <input type="text" v-model="displayValue" ref="feeinput" @keyup="inputChange">
+                    <input type="text" v-model="displayValue" ref="feeinput">
                 </form>
-                <keyboard v-model="input" :layouts="layout()" @percent="percentFee" @flat="flatFee" @input="change"/>
+                <keyboard v-model="displayValue" :layouts="layout()" @percent="percentFee" @flat="flatFee"/>
             </template>
         </v-popover>
     </div>
@@ -58,6 +58,11 @@ export default {
             viewFeeKeypad: false
         };
     },
+    watch: {
+        displayValue( newValue, oldValue ) {
+            this.inputChange();
+        }
+    },
     methods: {
         hideFeeKepad(e) {
             this.viewFeeKeypad = false;
@@ -65,46 +70,42 @@ export default {
         layout() {
             return '123|456|789|{<span class="keypord-icon flaticon-backspace"></span>:backspace}0'+wepos.currency_format_decimal_sep+'|{% '+this.name+':percent}{'+ wepos.currency_format_symbol + ' '+ this.name+':flat}';
         },
-        percentFee( keyboard ) {
-            this.$emit( 'inputfee', keyboard.value.toString(), 'percent' );
+        percentFee() {
+            this.$emit( 'inputfee', this.input, 'percent' );
             this.viewFeeKeypad = false;
             this.input='';
             this.displayValue='';
         },
-        flatFee( keyboard ) {
-            this.$emit( 'inputfee', keyboard.value.toString(), 'flat' );
+        flatFee() {
+            this.$emit( 'inputfee', this.input, 'flat' );
             this.viewFeeKeypad = false;
             this.input='';
             this.displayValue='';
-        },
-        change( value ){
-            let displayValue, inputValue;
-            displayValue = inputValue = value;
-
-            if ( "." !== wepos.currency_format_decimal_sep ) {
-                displayValue = value.replace( ".", wepos.currency_format_decimal_sep );
-                inputValue   = value.replace( wepos.currency_format_decimal_sep, "." )
-            }
-
-            this.displayValue = displayValue;
-            this.input        = inputValue;
-
-            jQuery( this.$refs.feeinput ).focus();
-
-            if ( this.input == '' ) {
-                jQuery( this.$refs.feeinput ).focus();
-            }
         },
         inputChange() {
-            if ( !isNaN( this.displayValue ) ) {
-                this.input = this.displayValue;
+            if ( this.isValidAmount( this.displayValue ) ) {
+                this.input = this.getFormattedValue( this.displayValue, wepos.currency_format_decimal_sep, "." );
             } else {
-                this.displayValue = this.input;
+                this.displayValue = this.getFormattedValue( this.input, ".", wepos.currency_format_decimal_sep );
             }
 
-            if ( this.input == '' ) {
-                jQuery( this.$refs.feeinput ).focus();
+            jQuery( this.$refs.feeinput ).focus();
+        },
+        getFormattedValue( value, charFrom, charTo ) {
+            let formattedValue = value;
+
+            if ( "." !== wepos.currency_format_decimal_sep ) {
+                formattedValue = value.replace( charFrom, charTo );
             }
+
+            return formattedValue;
+        },
+        isValidAmount( amount ) {
+            const decimalSep   = wepos.currency_format_decimal_sep;
+            const allowedChars = "^[0-9]*[" + decimalSep + "]{0,1}[0-9]*$";
+            const regexPattern = new RegExp( allowedChars, "gi" );
+
+            return amount.match( regexPattern );
         },
         showFeeKeypad(e) {
             e.preventDefault();

--- a/assets/src/frontend/components/FeeKeypad.vue
+++ b/assets/src/frontend/components/FeeKeypad.vue
@@ -77,15 +77,17 @@ export default {
             this.input='';
             this.displayValue='';
         },
-        change(value){
-            let displayValue  = value.replace( ".", wepos.currency_format_decimal_sep );
-            let originalValue = value.replace( wepos.currency_format_decimal_sep, "." );
+        change( value ){
+            let displayValue, inputValue;
+            displayValue = inputValue = value;
 
-            if ( ! isNaN( originalValue ) ) {
-                this.displayValue = displayValue;
+            if ( "." !== wepos.currency_format_decimal_sep ) {
+                displayValue = value.replace( ".", wepos.currency_format_decimal_sep );
+                inputValue   = value.replace( wepos.currency_format_decimal_sep, "." )
             }
 
-            this.input = originalValue;
+            this.displayValue = displayValue;
+            this.input        = inputValue;
 
             jQuery( this.$refs.feeinput ).focus();
 

--- a/assets/src/frontend/components/Home.vue
+++ b/assets/src/frontend/components/Home.vue
@@ -256,7 +256,7 @@
                                 <template v-if="cartdata.fee_lines.length > 0">
                                     <tr class="cart-meta-data" v-for="(fee,key) in cartdata.fee_lines">
                                         <template v-if="fee.type=='discount'">
-                                            <td class="label">{{ __( 'Discount', 'wepos' ) }} <span class="name">{{ fee.discount_type == 'percent' ? formatNumber( fee.value ) + '%' : formatPrice( fee.value ) }}</span></td>
+                                            <td class="label">{{ __( 'Discount', 'wepos' ) }} <span class="name">{{ getDiscountAmount( fee ) }}</span></td>
                                             <td class="price">&minus;{{ formatPrice( Math.abs( fee.total ) ) }}</td>
                                             <td class="action"><span class="flaticon-cancel-music" @click="removeFeeLine(key)"></span></td>
                                         </template>
@@ -277,7 +277,7 @@
                                                 <td class="action"><span class="flaticon-cancel-music" @click="removeFeeLine(key)"></span></td>
                                             </template>
                                             <template v-else>
-                                                <td class="label" @dblclick.prevent="editFeeData(key)">{{ __( 'Fee', 'wepos' ) }} <span class="name">{{ fee.name }} {{ fee.fee_type == 'percent' ? formatNumber( fee.value ) + '%' : formatPrice( fee.value ) }}</span></td>
+                                                <td class="label" @dblclick.prevent="editFeeData(key)">{{ __( 'Fee', 'wepos' ) }} <span class="name">{{ fee.name }} {{ getDiscountAmount( fee ) }}</span></td>
                                                 <td class="price">{{ formatPrice( Math.abs( fee.total ) ) }}</td>
                                                 <td class="action"><span class="flaticon-cancel-music" @click="removeFeeLine(key)"></span></td>
                                             </template>
@@ -451,11 +451,11 @@
                                 <template v-if="cartdata.fee_lines.length > 0">
                                     <li class="wepos-clearfix" v-for="(fee,key) in cartdata.fee_lines">
                                         <template v-if="fee.type=='discount'">
-                                            <span class="wepos-left">{{ __( 'Discount', 'wepos' ) }} <span class="metadata">{{ fee.name }} {{ fee.discount_type == 'percent' ? formatNumber( fee.value ) + '%' : formatPrice( fee.value ) }}</span></span>
+                                            <span class="wepos-left">{{ __( 'Discount', 'wepos' ) }} <span class="metadata">{{ fee.name }} {{ getDiscountAmount( fee ) }}</span></span>
                                             <span class="wepos-right">-{{ formatPrice( Math.abs( fee.total ) ) }}</span>
                                         </template>
                                         <template v-else>
-                                            <span class="wepos-left">{{ __( 'Fee', 'wepos' ) }} <span class="metadata">{{ fee.name }} {{ fee.fee_type == 'percent' ? formatNumber( fee.value ) + '%' : formatPrice( fee.value ) }}</span></span>
+                                            <span class="wepos-left">{{ __( 'Fee', 'wepos' ) }} <span class="metadata">{{ fee.name }} {{ getDiscountAmount( fee ) }}</span></span>
                                             <span class="wepos-right">{{ formatPrice( fee.total ) }}</span>
                                         </template>
                                     </li>
@@ -903,6 +903,9 @@ export default {
         },
         removeFeeLine( key ) {
             this.$store.dispatch( 'Cart/removeFeeLineItemsAction', key );
+        },
+        getDiscountAmount( fee ) {
+            return fee.discount_type == 'percent' ? this.formatNumber( fee.value ) + '%' : this.formatPrice( fee.value );
         },
         fetchProducts() {
             if ( this.page == 1 ) {

--- a/assets/src/frontend/components/Home.vue
+++ b/assets/src/frontend/components/Home.vue
@@ -905,7 +905,7 @@ export default {
             this.$store.dispatch( 'Cart/removeFeeLineItemsAction', key );
         },
         getDiscountAmount( fee ) {
-            return fee.discount_type == 'percent' ? this.formatNumber( fee.value ) + '%' : this.formatPrice( fee.value );
+            return fee.discount_type === 'percent' || fee.fee_type === 'percent' ? this.formatNumber( fee.value ) + '%' : this.formatPrice( fee.total );
         },
         fetchProducts() {
             if ( this.page == 1 ) {

--- a/assets/src/frontend/components/Home.vue
+++ b/assets/src/frontend/components/Home.vue
@@ -256,7 +256,7 @@
                                 <template v-if="cartdata.fee_lines.length > 0">
                                     <tr class="cart-meta-data" v-for="(fee,key) in cartdata.fee_lines">
                                         <template v-if="fee.type=='discount'">
-                                            <td class="label">{{ __( 'Discount', 'wepos' ) }} <span class="name">{{ fee.discount_type == 'percent' ? fee.value + '%' : formatPrice( fee.value ) }}</span></td>
+                                            <td class="label">{{ __( 'Discount', 'wepos' ) }} <span class="name">{{ fee.discount_type == 'percent' ? formatNumber( fee.value ) + '%' : formatPrice( fee.value ) }}</span></td>
                                             <td class="price">&minus;{{ formatPrice( Math.abs( fee.total ) ) }}</td>
                                             <td class="action"><span class="flaticon-cancel-music" @click="removeFeeLine(key)"></span></td>
                                         </template>
@@ -277,7 +277,7 @@
                                                 <td class="action"><span class="flaticon-cancel-music" @click="removeFeeLine(key)"></span></td>
                                             </template>
                                             <template v-else>
-                                                <td class="label" @dblclick.prevent="editFeeData(key)">{{ __( 'Fee', 'wepos' ) }} <span class="name">{{ fee.name }} {{ fee.fee_type == 'percent' ? fee.value + '%' : formatPrice( fee.value ) }}</span></td>
+                                                <td class="label" @dblclick.prevent="editFeeData(key)">{{ __( 'Fee', 'wepos' ) }} <span class="name">{{ fee.name }} {{ fee.fee_type == 'percent' ? formatNumber( fee.value ) + '%' : formatPrice( fee.value ) }}</span></td>
                                                 <td class="price">{{ formatPrice( Math.abs( fee.total ) ) }}</td>
                                                 <td class="action"><span class="flaticon-cancel-music" @click="removeFeeLine(key)"></span></td>
                                             </template>
@@ -451,11 +451,11 @@
                                 <template v-if="cartdata.fee_lines.length > 0">
                                     <li class="wepos-clearfix" v-for="(fee,key) in cartdata.fee_lines">
                                         <template v-if="fee.type=='discount'">
-                                            <span class="wepos-left">{{ __( 'Discount', 'wepos' ) }} <span class="metadata">{{ fee.name }} {{ fee.discount_type == 'percent' ? fee.value + '%' : formatPrice( fee.value ) }}</span></span>
+                                            <span class="wepos-left">{{ __( 'Discount', 'wepos' ) }} <span class="metadata">{{ fee.name }} {{ fee.discount_type == 'percent' ? formatNumber( fee.value ) + '%' : formatPrice( fee.value ) }}</span></span>
                                             <span class="wepos-right">-{{ formatPrice( Math.abs( fee.total ) ) }}</span>
                                         </template>
                                         <template v-else>
-                                            <span class="wepos-left">{{ __( 'Fee', 'wepos' ) }} <span class="metadata">{{ fee.name }} {{ fee.fee_type == 'percent' ? fee.value + '%' : formatPrice( fee.value ) }}</span></span>
+                                            <span class="wepos-left">{{ __( 'Fee', 'wepos' ) }} <span class="metadata">{{ fee.name }} {{ fee.fee_type == 'percent' ? formatNumber( fee.value ) + '%' : formatPrice( fee.value ) }}</span></span>
                                             <span class="wepos-right">{{ formatPrice( fee.total ) }}</span>
                                         </template>
                                     </li>


### PR DESCRIPTION
Previously, in the `viewPOS` frontend, the decimal separator for adding discount and fee only support dot (.).

Now, added support for comma (,) and all other decimal separators suported by wooCommerce.

Fix: #114 