### PR TITLE
fix: Variable product visible even no attributes used

### DIFF
--- a/assets/src/frontend/components/Home.vue
+++ b/assets/src/frontend/components/Home.vue
@@ -912,7 +912,7 @@ export default {
             if ( ( this.totalPages >= this.page ) ) {
                 wepos.api.get( wepos.rest.root + wepos.rest.posversion + '/products?status=publish&per_page=30&page=' + this.page )
                 .done( ( response, status, xhr ) => {
-                    this.products = this.products.concat( response );
+                    this.appendProducts( response );
                     this.page += 1;
                     this.totalPages = parseInt( xhr.getResponseHeader('X-WP-TotalPages') );
                     this.productLoading = false;
@@ -923,7 +923,26 @@ export default {
                 this.productLoading = false;
             }
         },
+        appendProducts( products ) {
+            products.forEach( product => {
+                if ( "variable" === product.type && this.isAllVariationsDisabled( product ) ) {
+                    return;
+                }
 
+                this.products = this.products.concat(product);
+            });
+        },
+        isAllVariationsDisabled( product ) {
+            let isDisabled = true;
+
+            product.attributes.forEach( attribute => {
+                if ( true === attribute.variation ) {
+                    isDisabled = false;
+                }
+            } );
+
+            return isDisabled;
+        },
         maybeRemoveDeletedProduct( cartData ) {
             return new Promise( ( resolve, reject ) => {
                 if ( ! cartData ) {

--- a/assets/src/frontend/components/Home.vue
+++ b/assets/src/frontend/components/Home.vue
@@ -929,7 +929,7 @@ export default {
                     return;
                 }
 
-                this.products = this.products.concat(product);
+                this.products = this.products.concat( product );
             });
         },
         isAllVariationsDisabled( product ) {


### PR DESCRIPTION
Previously, any variable product was visible to the POS frontend, even though attributes are not used for variations of that product.

Now, products are made invisible from the POS frontend if attributes are not used for variations.

Fixes: #118 