### PR TITLE
fix: Broken layout of smaller width print receipt

### DIFF
--- a/assets/src/frontend/components/PrintReceiptHtml.vue
+++ b/assets/src/frontend/components/PrintReceiptHtml.vue
@@ -112,6 +112,10 @@ export default {
 [v-cloak] {display: none}
 
 @media print {
+    @page {
+        margin: 0.5cm;
+    }
+
     body * {
         visibility: hidden;
     }
@@ -122,7 +126,7 @@ export default {
     }
 
     .wepos-checkout-print-wrapper {
-        color: #181818;
+        color: #000;
         font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
         display: inline-block !important;
     }
@@ -150,6 +154,7 @@ export default {
 
         .content {
             padding: 10px;
+
             table.sale-summary {
                 width: 100%;
                 border-collapse: collapse;
@@ -182,6 +187,7 @@ export default {
                             }
                             &.quantity {
                                 width: 12%;
+                                text-align: center;
                                 color: #758598;
                             }
                             &.price {

--- a/assets/src/frontend/components/PrintReceiptHtml.vue
+++ b/assets/src/frontend/components/PrintReceiptHtml.vue
@@ -149,6 +149,7 @@ export default {
         }
 
         .content {
+            padding: 10px;
             table.sale-summary {
                 width: 100%;
                 border-collapse: collapse;


### PR DESCRIPTION
Previously, the print receipt layout got broken for smaller than 5 inches width receipts. 

Now, the issue has been solved by this PR.

Fixes: https://github.com/weDevsOfficial/wepos-pro/issues/27