### PR TITLE
🧾 fix: Blurry numbers on print receipt

### DIFF
--- a/assets/src/frontend/components/PrintReceiptHtml.vue
+++ b/assets/src/frontend/components/PrintReceiptHtml.vue
@@ -127,7 +127,7 @@ export default {
 
     .wepos-checkout-print-wrapper {
         color: #000;
-        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-family: Helvetica, Verdana, Calibri, Arial, "Franklin Gothic", sans-serif;
         display: inline-block !important;
     }
 

--- a/assets/src/frontend/components/PrintReceiptHtml.vue
+++ b/assets/src/frontend/components/PrintReceiptHtml.vue
@@ -126,8 +126,8 @@ export default {
     }
 
     .wepos-checkout-print-wrapper {
-        color: #000;
-        font-family: Helvetica, Verdana, Calibri, Arial, "Franklin Gothic", sans-serif;
+        color: #000000;
+        font-family: Helvetica, Verdana, Calibri, Arial, "Franklin Gothic", sans-serif !important;
         display: inline-block !important;
     }
 


### PR DESCRIPTION
Previously, the amounts and other numbers were blurry on print receipts for several clients due to font availability.

Now, fixed the issue by this PR.

 * Fixes: #140 