### PR TITLE
🚀 enhance: Added support for WooCommerce customized order numbers

### DIFF
--- a/assets/src/frontend/components/Home.vue
+++ b/assets/src/frontend/components/Home.vue
@@ -837,7 +837,7 @@ export default {
                                 id: response.payment_method,
                                 title: response.payment_method_title
                             },
-                            order_id: response.id,
+                            order_id: response.number,
                             order_date: response.date_created,
                             cashamount: this.cashAmount.toString(),
                             changeamount: this.changeAmount.toString()


### PR DESCRIPTION
Previously, there was no support for WooCommerce customized order numbers.

Now, added support for customized order numbers by this PR.

* Fixes: #149.