### PR TITLE
🎯 fix: Unable to create order for existing customers without billing email

### DIFF
--- a/assets/src/frontend/components/Home.vue
+++ b/assets/src/frontend/components/Home.vue
@@ -1092,6 +1092,10 @@ export default {
         },
 
         selectCustomer( customer ) {
+            if ( customer.email && ! customer.billing.email ) {
+                customer.billing.email = customer.email;
+            }
+
             this.$store.dispatch( 'Order/setCustomerAction', customer );
         },
         selectVariationProduct( product ) {


### PR DESCRIPTION
* Fixes: https://github.com/getdokan/plugin-internal-tasks/issues/398

### Before:
![Screenshot at Jun 04 12-37-25](https://github.com/weDevsOfficial/wepos-pro/assets/82957718/4d5ce862-112d-4f6f-9ae0-810187c3174e)

### After:
Error alert for missing billing paramerter has been removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the system so that when a customer’s email is available and the billing email isn’t yet set, the billing email is automatically populated. This adjustment enhances data consistency and streamlines the user experience when managing billing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->