### PR TITLE
feat: Add refund support to Cash payment gateway and refactor initialization

### DIFF
--- a/includes/Gateways/Cash.php
+++ b/includes/Gateways/Cash.php
@@ -142,12 +142,12 @@ class Cash extends \WC_Payment_Gateway {
         $order = wc_get_order( $order_id );
 
         if ( ! $this->can_refund_order( $order ) ) {
-            return new \WP_Error( 'error', __( 'Refund failed.', 'woocommerce' ) );
+            return new \WP_Error( 'error', __( 'Refund failed.', 'wepos' ) );
         }
 
         $order->add_order_note(
         /* translators: 1: Refund amount, 2: Refund reason */
-            sprintf( __( 'Refunded %1$s - Reason: %2$s', 'woocommerce' ), $amount, $reason ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+            sprintf( __( 'Refunded %1$s - Reason: %2$s', 'wepos' ), $amount, $reason ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
         );
 
         $order->update_status(OrderInternalStatus::REFUNDED );

--- a/includes/Gateways/Cash.php
+++ b/includes/Gateways/Cash.php
@@ -1,6 +1,8 @@
 <?php
 namespace WeDevs\WePOS\Gateways;
 
+use Automattic\WooCommerce\Enums\OrderInternalStatus;
+
 /**
 * Cash gateway payment for POS
 */
@@ -36,6 +38,9 @@ class Cash extends \WC_Payment_Gateway {
         $this->method_title       = __( 'Cash', 'wepos' );
         $this->method_description = __( 'Have your customers pay with cash', 'wepos' );
         $this->has_fields         = false;
+        $this->supports           = array(
+            'refunds'
+        );
     }
 
     /**
@@ -118,4 +123,32 @@ class Cash extends \WC_Payment_Gateway {
         );
     }
 
+    /**
+     * Process refund.
+     *
+     * If the gateway declares 'refunds' support, this will allow it to refund.
+     * a passed in amount.
+     *
+     * @param  int        $order_id Order ID.
+     * @param  float|null $amount Refund amount.
+     * @param  string     $reason Refund reason.
+     * @return bool|\WP_Error True or false based on success, or a WP_Error object.
+     */
+    public function process_refund( $order_id, $amount = null, $reason = '' ) {
+        $order = wc_get_order( $order_id );
+
+        if ( ! $this->can_refund_order( $order ) ) {
+            return new \WP_Error( 'error', __( 'Refund failed.', 'woocommerce' ) );
+        }
+
+        $order->add_order_note(
+        /* translators: 1: Refund amount, 2: Refund reason */
+            sprintf( __( 'Refunded %1$s - Reason: %2$s', 'woocommerce' ), $amount, $reason ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+        );
+
+        $order->update_status(OrderInternalStatus::REFUNDED );
+        $order->save();
+
+        return true;
+    }
  }

--- a/includes/Gateways/Cash.php
+++ b/includes/Gateways/Cash.php
@@ -8,6 +8,10 @@ use Automattic\WooCommerce\Enums\OrderInternalStatus;
 */
 class Cash extends \WC_Payment_Gateway {
 
+    protected $instructions;
+    protected $enable_for_methods;
+    protected $enable_for_virtual;
+
     /**
      * Constructor for the gateway.
      */

--- a/includes/Gateways/Cash.php
+++ b/includes/Gateways/Cash.php
@@ -87,7 +87,7 @@ class Cash extends \WC_Payment_Gateway {
             return true;
         }
 
-        return parent::is_available();
+        return parent::is_available() && wepos_is_frontend();
     }
 
     /**

--- a/includes/Gateways/Manager.php
+++ b/includes/Gateways/Manager.php
@@ -14,7 +14,7 @@ class Manager {
      */
     public function __construct() {
         add_action( 'plugins_loaded', [ $this, 'init_gateways' ], 11, 1 );
-        add_action( 'woocommerce_payment_gateways', [ $this, 'payment_gateways' ] );
+        add_filter( 'woocommerce_payment_gateways', [ $this, 'payment_gateways' ] );
     }
 
     /**

--- a/wepos.php
+++ b/wepos.php
@@ -313,6 +313,7 @@ final class WePOS {
     public function init_hooks() {
         add_action( 'init', [ $this, 'init_classes' ] );
         add_action( 'init', [ $this, 'localization_setup' ] );
+        add_action( 'wepos_loaded', [ $this, 'load_payment_gateways' ] );
     }
 
     /**
@@ -340,9 +341,6 @@ final class WePOS {
         $this->container['common'] = new WeDevs\WePOS\Common();
         $this->container['rest']   = new WeDevs\WePOS\REST\Manager();
         $this->container['assets'] = new WeDevs\WePOS\Assets();
-
-        // Payment gateway manager
-        $this->container['gateways'] = new \WeDevs\WePOS\Gateways\Manager();
     }
 
     /**
@@ -352,6 +350,18 @@ final class WePOS {
      */
     public function localization_setup() {
         load_plugin_textdomain( 'wepos', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+    }
+
+    /**
+     * Load the payment gateways.
+     *
+     * @since WEPOS_SINCE
+     *
+     * @return void
+     */
+    public function load_payment_gateways() {
+        // Payment gateway manager
+        $this->container['gateways'] = new \WeDevs\WePOS\Gateways\Manager();
     }
 
     /**


### PR DESCRIPTION
This PR adds refund support to the Cash payment gateway in the wePOS plugin and improves the gateway initialization process.

### Changes made:
- Added support for processing refunds in the Cash payment gateway
- Implemented the `process_refund()` method for Cash gateway with proper order status updates
- Changed gateway registration from `add_action` to `add_filter` for proper WooCommerce integration
- Refactored payment gateway initialization to use the 'wepos_loaded' hook for better loading sequence

## Changelog entry
```
- **feat**: Add `refund` support card payment method.
```

## Related Issues
* Closes https://github.com/getdokan/wepos-pro/issues/44
* Closes https://github.com/getdokan/plugin-internal-tasks/issues/392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced refund processing for cash payments, allowing merchants to issue refunds directly.
  - Enhanced payment gateway loading for a more reliable and streamlined point-of-sale experience.

- **Refactor**
  - Updated the payment gateway integration approach to ensure smoother transaction handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->