### PR TITLE
feat: Add High Performance Order Storage support for WooCommerce compatibility

### DIFF
--- a/wepos.php
+++ b/wepos.php
@@ -84,6 +84,9 @@ final class WePOS {
         add_action( 'init', [ $this, 'add_rewrite_rules' ] );
         add_filter( 'query_vars', [ $this, 'register_query_var' ] );
 
+        // Declaring High Performance Order Storage Support
+        add_action( 'before_woocommerce_init', [ $this, 'declare_woocommerce_feature_compatibility' ] );
+
         add_action( 'plugins_loaded', [ $this, 'woocommerce_not_loaded' ], 11 );
 
         // Admin notice for WooCommerce dependency
@@ -117,6 +120,20 @@ final class WePOS {
 
         if (  current_user_can( 'activate_plugins' ) ) {
             require_once WEPOS_PATH . '/templates/woocommerce-dependency-notice.php';
+        }
+    }
+
+    /**
+     * Add High Performance Order Storage Support
+     *
+     * @since WEPOS_SINCE
+     * @see https://developer.woocommerce.com/docs/hpos-extension-recipe-book/
+     *
+     * @return void
+     */
+    public function declare_woocommerce_feature_compatibility() {
+        if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+            \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', WEPOS_FILE, true );
         }
     }
 


### PR DESCRIPTION
This PR adds compatibility for WooCommerce's High-Performance Order Storage (HPOS) feature to the wePOS plugin. When HPOS was enabled, orders were not appearing in the wePOS interface due to incompatible query methods.

### Changes made:
- Added HPOS compatibility declaration using WooCommerce's FeaturesUtil class
- Added reference link to WooCommerce developer documentation for HPOS query APIs

## Changelog entry
```
- **update**: Added High Performance Order Storage support.
```

## Related Issues
* Closes https://github.com/getdokan/wepos-pro/issues/78
* Closes https://github.com/getdokan/plugin-internal-tasks/issues/388

## Testing Instructions
1. Enable HPOS in WooCommerce settings (WooCommerce > Settings > Advanced > Features)
2. Create test orders with the wePOS interface
3. Verify orders appear correctly in the wePOS interface
4. Verify existing orders created via wePOS are properly displayed

## Screenshots/Video
described in issue description

## Technical Notes
- The changes follow WooCommerce's recommended approach for HPOS compatibility
- This is a backward-compatible change that works with both traditional post-based orders and the new custom order tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added compatibility with WooCommerce's High Performance Order Storage (HPOS) feature, ensuring smoother integration with WooCommerce's custom order tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->