### PR TITLE
Fix: exclude POS cash orders from vendor withdrawable balance

### DIFF
--- a/includes/Dokan.php
+++ b/includes/Dokan.php
@@ -29,6 +29,7 @@ class Dokan {
 
         // Exclude wepos_cash payments from vendor withdrawal balance
         add_filter( 'dokan_order_should_exclude_from_vendor_balance', [ $this, 'exclude_wepos_cash_payment' ], 10, 5 );
+        add_filter( 'dokan_order_refund_should_exclude_from_vendor_balance', [ $this, 'prevent_wepos_cash_refund_deduction' ], 10, 6 );
     }
 
     /**
@@ -184,6 +185,31 @@ class Dokan {
      * @return bool True if payment should be excluded, false otherwise.
      */
     public function exclude_wepos_cash_payment( $should_exclude, $order, $order_id, $new_status, $exclude_cod ) {
+        // Check if the payment method is wepos_cash
+        if ( 'wepos_cash' === $order->get_payment_method() ) {
+            return true;
+        }
+
+        return $should_exclude;
+    }
+
+    /**
+     * Prevent reducing refund amount from vendor balance for wepos_cash payments
+     *
+     * When a refund is processed for an order paid via wepos_cash method,
+     * prevent deducting the refund amount from the vendor's balance.
+     *
+     * @since 1.3.3
+     *
+     * @param bool     $should_exclude Whether to exclude from balance deduction.
+     * @param WC_Order $order          Order object.
+     * @param int      $order_id       Order ID.
+     * @param string   $new_status     New order status.
+     * @param bool     $exclude_cod    Whether exclude COD option is enabled.
+     *
+     * @return bool True if refund should not reduce vendor balance, false otherwise.
+     */
+    public function prevent_wepos_cash_refund_deduction( $should_exclude, $order, $order_id, $new_status, $exclude_cod, $refund_order ) {
         // Check if the payment method is wepos_cash
         if ( 'wepos_cash' === $order->get_payment_method() ) {
             return true;

--- a/includes/Dokan.php
+++ b/includes/Dokan.php
@@ -26,6 +26,9 @@ class Dokan {
 
         // If vendor created via REST API
         add_action( 'dokan_new_vendor', [ $this, 'after_create_vendor_via_rest' ], 15 );
+
+        // Exclude wepos_cash payments from vendor withdrawal balance
+        add_filter( 'dokan_order_should_exclude_from_vendor_balance', [ $this, 'exclude_wepos_cash_payment' ], 10, 5 );
     }
 
     /**
@@ -162,5 +165,30 @@ class Dokan {
         ];
 
         return $settings_fields;
+    }
+
+    /**
+     * Exclude wepos_cash payments from vendor withdrawal balance
+     *
+     * When a payment is made via wepos_cash method, exclude it from
+     * the vendor's withdrawal balance calculation.
+     *
+     * @since 1.3.3
+     *
+     * @param bool     $should_exclude Whether to exclude the payment.
+     * @param WC_Order $order          Order object.
+     * @param int      $order_id       Order ID.
+     * @param string   $new_status     New order status.
+     * @param bool     $exclude_cod    Whether exclude COD option is enabled.
+     *
+     * @return bool True if payment should be excluded, false otherwise.
+     */
+    public function exclude_wepos_cash_payment( $should_exclude, $order, $order_id, $new_status, $exclude_cod ) {
+        // Check if the payment method is wepos_cash
+        if ( $order->get_payment_method() === 'wepos_cash' ) {
+            return true;
+        }
+
+        return $should_exclude;
     }
 }

--- a/includes/Dokan.php
+++ b/includes/Dokan.php
@@ -185,7 +185,7 @@ class Dokan {
      */
     public function exclude_wepos_cash_payment( $should_exclude, $order, $order_id, $new_status, $exclude_cod ) {
         // Check if the payment method is wepos_cash
-        if ( $order->get_payment_method() === 'wepos_cash' ) {
+        if ( 'wepos_cash' === $order->get_payment_method() ) {
             return true;
         }
 


### PR DESCRIPTION
### Related Pull Request(s)

* Full PR Link https://github.com/getdokan/dokan/pull/3079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wepos cash payments are now excluded from vendor withdrawal balance calculations so vendor payouts and available balances reflect only eligible payment types.
* **Bug Fixes**
  * Prevents wepos cash payments and refunds from incorrectly affecting vendor withdrawable funds, improving accuracy of balance reporting and withdrawal requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->