### PR TITLE
fix: Product pricing logic to include raw price attributes and improve tax calculations.

### DIFF
--- a/docs/tax-handling.md
+++ b/docs/tax-handling.md
@@ -1,0 +1,193 @@
+## wePOS Tax Handling (Inclusive / Exclusive)
+
+- [Overview](#overview)
+- [The Two WooCommerce Settings](#the-two-woocommerce-settings)
+- [Display Layer vs Order Payload Layer](#display-layer-vs-order-payload-layer)
+- [Server-Side: Product Response](#server-side-product-response)
+- [Client-Side: Hydration into the Store](#client-side-hydration-into-the-store)
+- [Cart Math in the Store](#cart-math-in-the-store)
+- [Order Payload Construction](#order-payload-construction)
+- [End-to-End Flow](#end-to-end-flow)
+- [Behavior Matrix](#behavior-matrix)
+- [Edge Cases](#edge-cases)
+- [Testing](#testing)
+
+### Overview
+
+WooCommerce exposes two independent tax settings that wePOS must honor when products are added to the cart and an order is saved through the REST API. The most common production bug in this area is conflating the two — using the *display* price (which respects the cart-display setting) as the *order payload* price (which is interpreted under the prices-include-tax setting). When the two settings disagree, the order total saved on the server no longer matches what the cashier saw on the screen.
+
+wePOS resolves this by keeping the two concerns on separate fields of the cart item: display prices drive the UI, raw prices drive the order payload sent to `wc/v3/orders`.
+
+### The Two WooCommerce Settings
+
+| Option key | UI label | Role |
+|---|---|---|
+| `woocommerce_prices_include_tax` | WooCommerce → Settings → Tax → *Prices entered with tax* | Declares whether the stored `regular_price` / `sale_price` on a product is **tax-inclusive** or **tax-exclusive**. This is the contract for the order REST API — `WC_REST_Orders_V2_Controller::save_object` flags the order via `$object->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) )` and then `calculate_totals()` interprets every posted `total` / `subtotal` under that flag. |
+| `woocommerce_tax_display_cart` | WooCommerce → Settings → Tax → *Display prices during cart and checkout* | A **display-only** preference: show cart prices including or excluding tax. Independent of how prices are stored. |
+| `woocommerce_tax_display_shop` | WooCommerce → Settings → Tax → *Display prices in the shop* | Display-only preference for the shop catalog. **wePOS does not use this setting** — the POS uses the cart display setting for the cashier UI. |
+
+> The cart display setting changes what number the cashier sees. The prices-include-tax setting changes how WooCommerce *interprets* a posted number on the order endpoint. These are independent levers and they may disagree.
+
+### Display Layer vs Order Payload Layer
+
+The cart item carries **two** parallel price pairs:
+
+| Field on `POSCartItem` | Source | Used by |
+|---|---|---|
+| `regular_price` / `sale_price` | Server-computed display price (`regular_display_price` / `sales_display_price` injected by [`Manager::product_response`](../includes/REST/Manager.php#L63)) | Cart UI — subtotal row, per-line price, strikethrough on sale |
+| `raw_regular_price` / `raw_sale_price` | Untouched `product.regular_price` / `product.sale_price` from WC | Order payload only — passed as `line_items[].total` / `subtotal` so WC interprets them against `woocommerce_prices_include_tax` |
+
+This separation is the entire fix. The display layer math (subtotal, per-line tax hint, total tax row) is unchanged from the legacy Vue UI. The order layer now sends a value that means the same thing on both sides of the wire.
+
+Type declarations live in [`src/frontend/types/index.ts`](../src/frontend/types/index.ts) (`POSCartItem`).
+
+### Server-Side: Product Response
+
+[`Manager::product_response`](../includes/REST/Manager.php#L63) is hooked into the product REST response and enriches each product with three tax-aware fields:
+
+| Output field | Computed as | Notes |
+|---|---|---|
+| `regular_display_price` | `regular_excl_tax + regular_tax` when `tax_display_cart === 'incl'`, otherwise `regular_excl_tax` | Always derived from the **regular** price base |
+| `sales_display_price` | `sale_excl_tax + sale_tax` when `tax_display_cart === 'incl'`, otherwise `sale_excl_tax` | Always derived from the **sale** price base; `0` when the product is not on sale |
+| `tax_amount` | `sale_tax` when on sale, otherwise `regular_tax` | Drives the per-line tax label and the "Including Tax" hint client-side |
+
+**Why compute tax per-price.** WooCommerce's `wc_get_price_including_tax( $product )` returns the *effective* price (sale price when on sale), so deriving a single `$tax_amount` from it and adding the same amount to both the regular and sale display lines produces the wrong number on the regular row of an on-sale product. The function computes `regular_tax` and `sale_tax` from their own base prices independently.
+
+**Why these getters honor `prices_include_tax`.** Both `wc_get_price_excluding_tax()` and `wc_get_price_including_tax()` consult `woocommerce_prices_include_tax` internally to interpret the input `price` argument. Removing the explicit `if ( 'no' === $tax_calculations )` branch from the previous implementation did not skip that logic — it pushed responsibility to WooCommerce, which already knew. The old code's outer `if/else` arms were textually identical, so the branch was dead code.
+
+```mermaid
+flowchart TD
+    A["Product REST request"] --> B["WC default product_response"]
+    B --> C["Manager::product_response filter"]
+    C --> D["Read woocommerce_tax_display_cart"]
+    D --> E["wc_get_price_excluding_tax(regular_price)"]
+    D --> F["wc_get_price_including_tax(regular_price)"]
+    D --> G["wc_get_price_excluding_tax(sale_price)"]
+    D --> H["wc_get_price_including_tax(sale_price)"]
+    E --> I["regular_tax = incl - excl"]
+    F --> I
+    G --> J["sale_tax = incl - excl"]
+    H --> J
+    I --> K["regular_display_price"]
+    J --> L["sales_display_price"]
+    I --> M{"is_on_sale?"}
+    J --> M
+    M -- Yes --> N["tax_amount = sale_tax"]
+    M -- No --> O["tax_amount = regular_tax"]
+    K --> P["Augmented JSON response"]
+    L --> P
+    N --> P
+    O --> P
+```
+
+### Client-Side: Hydration into the Store
+
+On POS load, [`pages/Home.tsx`](../src/frontend/pages/Home.tsx) runs two effects that synchronize the cart store with WooCommerce settings:
+
+1. Mirror `settings.woo_tax` → `cart.tax_display_cart` via [`setTaxDisplayMode`](../src/frontend/store/cart/actions.ts#L139).
+2. Fetch `/wepos/v1/taxes` and dispatch [`setAvailableTax`](../src/frontend/store/cart/actions.ts#L146).
+
+When a product is added to the cart, the cart item is hydrated from the product response:
+
+```ts
+regular_price:     pickRegularDisplayPrice(product), // regular_display_price ?? regular_price
+sale_price:        pickSaleDisplayPrice(product),    // sales_display_price  ?? sale_price ?? regular_price
+raw_regular_price: toFiniteNumber(product.regular_price),
+raw_sale_price:    toFiniteNumber(product.sale_price),
+tax_amount:        toFiniteNumber(product.tax_amount),
+```
+
+Variations use the same pattern in [`ProductVariationSelector.tsx`](../src/frontend/components/ProductVariationSelector.tsx) and fall back to the parent product's `tax_amount` when the variation does not report its own. Misc/custom products (cashier-entered) set `raw_*` equal to the entered price — there is no display/raw distinction because WC interprets that single value under `prices_include_tax`.
+
+Helpers: [`pickRegularDisplayPrice`](../src/frontend/utils/helpers.ts#L191), [`pickSaleDisplayPrice`](../src/frontend/utils/helpers.ts#L198), [`toFiniteNumber`](../src/frontend/utils/helpers.ts#L163), [`firstPresentNumber`](../src/frontend/utils/helpers.ts#L170).
+
+### Cart Math in the Store
+
+Two selectors in [`store/cart/selectors.ts`](../src/frontend/store/cart/selectors.ts) drive every tax surface in the cart UI:
+
+| Selector | Returns | Purpose |
+|---|---|---|
+| `getTotalLineTax` | `Σ \|tax_amount × qty\|` over every line | Raw line tax, **never zeroed**. Powers the "Including Tax" hint under the Subtotal row. |
+| `getTotalTax` | Line tax (zeroed when `tax_display_cart === 'incl'` so it isn't double-counted in the visible total) + fee tax + coupon tax adjustment. Falls back to `server_order.total_tax` once the order is saved. | The headline "Tax" row in the cart. Direct port of the legacy Vue `Cart.module.js:52-102`. |
+
+The split exists because the Subtotal row in `incl` mode already includes tax — adding line tax to the visible total again would double-count. The "Including Tax" hint still needs the raw figure, so `getTotalLineTax` stays unconditional.
+
+### Order Payload Construction
+
+[`Home::buildOrderPayload`](../src/frontend/pages/Home.tsx#L883) builds the body sent to `wc/v3/orders`. The critical change: `line_items[].total` and `subtotal` are computed from `raw_*` prices, not the display prices.
+
+```ts
+const rawRegular = item.raw_regular_price ?? item.regular_price; // fallback for legacy in-memory carts
+const rawSale    = item.raw_sale_price    ?? item.sale_price;
+const unitPrice  = item.on_sale ? rawSale : rawRegular;
+
+lineItem.subtotal = (unitPrice * item.quantity).toFixed(2);
+lineItem.total    = (unitPrice * item.quantity).toFixed(2);
+```
+
+Misc/custom products post their cashier-entered `price` directly — WC interprets it against `prices_include_tax` exactly like any other product. The display path (cart UI subtotal, per-line price, total tax row) keeps reading `regular_price` / `sale_price` and is unaffected.
+
+### End-to-End Flow
+
+```mermaid
+sequenceDiagram
+    participant WC as WooCommerce DB
+    participant API as wepos/v1 + wc/v3
+    participant POS as wePOS React UI
+    participant Store as Cart Store
+    participant Order as Order REST
+
+    WC->>API: regular_price, sale_price (stored value)
+    API->>POS: product + regular_display_price, sales_display_price, tax_amount
+    Note over POS,Store: On "Add to cart"
+    POS->>Store: cart item { regular_price=display, sale_price=display, raw_regular_price, raw_sale_price, tax_amount }
+    Store-->>POS: subtotal, per-line tax, total tax (display layer)
+    Note over POS,Order: On "Save order"
+    POS->>Order: line_items[].total = raw * qty
+    Order->>WC: calculate_totals() under prices_include_tax flag
+    WC-->>Order: stored order total
+    Order-->>POS: server_order.total_tax (selectors switch over to this)
+```
+
+### Behavior Matrix
+
+For each combination of (`prices_include_tax` × `tax_display_cart`), the cashier total must equal the saved order total.
+
+| `prices_include_tax` | `tax_display_cart` | Cart UI shows | Order saved as |
+|---|---|---|---|
+| no  | excl | $100 + $10 tax = $110 | $110 |
+| no  | **incl** | $110 ("Including Tax" hint) | $110 |
+| yes | **excl** | $90.91 + $9.09 tax = $100 | $100 |
+| yes | incl | $100 ("Including Tax" hint) | $100 |
+
+The middle two rows are where the two settings disagree — those are the rows the fix targets.
+
+#### Sale-product secondary fix
+
+`regular=$100, sale=$80, tax=10%, prices_include_tax=no, tax_display_cart=incl`:
+
+| Field | Before fix | After fix |
+|---|---|---|
+| `regular_display_price` | $108 (sale tax added to regular) | $110 |
+| `sales_display_price` | $88 | $88 |
+| Per-row tax shown | $8 on both rows | $10 (regular) / $8 (sale) |
+
+### Edge Cases
+
+- **Empty sale price.** `$sale_price === ''` short-circuits `sale_excl_tax` / `sale_incl_tax` to `0.0`. Without this guard, `wc_get_price_excluding_tax( $product, [ 'price' => '' ] )` would coerce to `0` *after* a tax computation and emit `E_WARNING` on some PHP versions.
+- **Variation `tax_amount` missing.** [`ProductVariationSelector.tsx`](../src/frontend/components/ProductVariationSelector.tsx) falls back to the parent product's `tax_amount` via `firstPresentNumber( variation.tax_amount, product.tax_amount )` so the per-line label still renders.
+- **Legacy in-memory carts.** Cart items hydrated before this build do not have `raw_*` fields. `buildOrderPayload` falls back to `regular_price` / `sale_price` so existing carts keep working — they will save with the old (pre-fix) behavior until the cart is refreshed.
+- **Server round-trip.** After `wc/v3/orders` returns, `getTotalTax` switches from local computation to `server_order.total_tax`. Any subsequent UI render reflects WC's authoritative number, not the local approximation.
+- **Misc/custom products.** No display/raw split — the cashier enters a single price and WC interprets it under `prices_include_tax`. The cart UI shows the same number the cashier typed.
+
+### Testing
+
+1. WooCommerce → Settings → Tax → set a 10% standard rate.
+2. For each of the four `prices_include_tax × tax_display_cart` permutations:
+   - Add the $100 regular product.
+   - Confirm cart UI total.
+   - Place the order, open it in `wp-admin → Orders`, confirm the saved total equals the cart total.
+3. Sale-product check: add a `regular=$100, sale=$80` product under `prices_include_tax=no, tax_display_cart=incl`. Verify the strikethrough reads **$110** and the active line reads **$88**.
+4. Variations: add a variable product, confirm the variation's `tax_amount` (or parent fallback) labels the row.
+5. Misc/custom item: add a cashier-entered $50 product. The saved order total must equal `$50` in `excl` storage, and `$50` final-inclusive in `yes` storage.
+6. Fees and coupons: add a taxable percent fee and a taxable coupon. Confirm the total tax row reflects them before the order is saved (local computation) and continues to match after save (server response).

--- a/docs/tax-handling.md
+++ b/docs/tax-handling.md
@@ -108,11 +108,35 @@ Three selectors in [`store/cart/selectors.ts`](./../src/frontend/store/cart/sele
 |---|---|---|
 | `getTaxDisplayMode` | `'incl' \| 'excl'` from the store | Cart UI label switches (single source of truth — Cart components must not re-read from `settings`) |
 | `getTotalLineTax` | `Σ tax_amount × qty` over every line | "Including Tax" hint under Subtotal. Never zeroed, even in `incl` mode. |
-| `getTotalTax` | Line tax (zeroed when `tax_display_cart === 'incl'` to avoid double-counting) + fee tax + coupon tax adjustment. Falls back to `server_order.total_tax` once the order is saved. | Headline "Tax" row. Direct port of legacy `Cart.module.js:52-102`. |
+| `getTotalTax` | Line tax (zeroed when `tax_display_cart === 'incl'` to avoid double-counting) + fee tax + coupon tax adjustment. After save, switches to `server_order.total_tax`; if the server reports `0`, falls back to the **total/sub gap** (see [WC-silent gap fallback](#wc-silent-gap-fallback)). | Headline "Tax" row. Direct port of legacy `Cart.module.js:52-102`. |
 
 The line-tax / total-tax split exists because in `incl` mode the Subtotal row already contains tax — adding line tax to the visible total would double-count. The "Including Tax" hint still needs the raw figure, so `getTotalLineTax` stays unconditional.
 
 **Coupon adjustment in `incl` mode.** Because `lineTax` is forced to `0` in `incl` mode, `couponTaxReduction = (discountAmount / subtotal) * 0 = 0`. This is mathematically correct: the incl-mode subtotal already bakes tax into the line price, so a coupon reducing `$X` simultaneously reduces both the price and the tax bundled inside it — no separate reduction line is needed.
+
+### WC-silent gap fallback
+
+After `saveToServer` runs, WC sometimes returns the order with `total_tax = "0"` even though the line totals already bundle the tax. This happens when WC's `WC_Tax::find_rates()` can't resolve a tax rate from the order's location — typically a guest order with no billing address, where the standard rate has a country restriction that doesn't match the shop base.
+
+Without a fallback the cart would display `Subtotal $90.91` and `Order Total $100` with the Tax row hidden — a math contradiction visible to the cashier and a real loss of tax info in the printed receipt (`Tax Total $0.00`).
+
+`getTotalTax` handles this by deriving tax from the gap between `server.total` and the sum of non-tax components:
+
+```ts
+gap = server.total - (subtotal − totalDiscount + totalFee + totalShipping)
+return gap > 0.01 ? gap : 0
+```
+
+Properties:
+
+- **Normal case** (server reports tax): `serverTax > 0`, used as-is. Gap path never triggers.
+- **WC-silent case** (server reports `0` but bundled tax exists): gap is positive, returned. Cashier sees `Subtotal + Tax = Order Total`.
+- **True zero-tax case** (server reports `0`, no bundled tax): gap is `0`, returned. No Tax row.
+- **`incl` mode**: `subtotal` already includes tax, so `subtotal == server.total` and gap is `0`. No Tax row, which is correct (tax is bundled into the displayed price).
+
+The print receipt mirrors the same logic in [`Home::processPayment`](./../src/frontend/pages/Home.tsx) when building `printdata.taxtotal`, so the printed `Tax Total` value matches the cart's Tax row in every case.
+
+> **Note:** the gap fallback is a display safety net. The order saved in WC still has `total_tax = "0"` in the database — accounting / tax reports will not see this tax. The root fix is to ensure WC can resolve a rate (set a shop base country, or supply a billing country on the order). The fallback only prevents UI inconsistency.
 
 **Extension point.** `getTotalTax` runs the result through the `wepos_cart_total_tax` filter. The payload is `{ lineTax, feeTax, couponTaxReduction }` — derived totals only, never the live store reference — so a filter callback cannot mutate cart state from inside the filter.
 
@@ -352,6 +376,13 @@ Setup: variable product with a variation `regular_price=$100`, 10% tax.
 
 - **Cart total snaps to a different number after "Save to Server"**
   - Expected — `getTotalTax` switches from the local computation to `server_order.total_tax`. If the snap is more than rounding noise, the local computation drifted from WC; reconcile by reading the row that fired in `getTotalTax` and comparing to WC's `tax_lines` in the saved order.
+
+- **Tax row hidden after Save to Server / Back to Sale (even though it was visible before)**
+  - WC returned `total_tax = "0"` because it couldn't resolve a tax rate from the order's location (guest order with no billing country, or shop base country missing). The selector now falls back to the [total/sub gap](#wc-silent-gap-fallback) so the row reappears — verify the cart Order Total truly equals `subtotal + fees + shipping − discounts + visible_tax`.
+  - Permanent fix: set a country on the shop base (`WooCommerce → Settings → General → Store address`), or supply a billing country on the order so `WC_Tax::find_rates()` can match. Otherwise the saved order will still record `total_tax = 0` in the database even though the UI displays the correct breakdown.
+
+- **Printed receipt shows `Tax Total $0.00` while Order Total includes tax**
+  - Same root cause as above — `parseFloat(orderResponse.total_tax)` returns `0`. The receipt builder in `Home::processPayment` now applies the same gap fallback as the selector, so `printdata.taxtotal` matches what the cashier sees in the cart.
 
 
 ## References

--- a/docs/tax-handling.md
+++ b/docs/tax-handling.md
@@ -108,35 +108,41 @@ Three selectors in [`store/cart/selectors.ts`](./../src/frontend/store/cart/sele
 |---|---|---|
 | `getTaxDisplayMode` | `'incl' \| 'excl'` from the store | Cart UI label switches (single source of truth — Cart components must not re-read from `settings`) |
 | `getTotalLineTax` | `Σ tax_amount × qty` over every line | "Including Tax" hint under Subtotal. Never zeroed, even in `incl` mode. |
-| `getTotalTax` | Line tax (zeroed when `tax_display_cart === 'incl'` to avoid double-counting) + fee tax + coupon tax adjustment. After save, switches to `server_order.total_tax`; if the server reports `0`, falls back to the **total/sub gap** (see [WC-silent gap fallback](#wc-silent-gap-fallback)). | Headline "Tax" row. Direct port of legacy `Cart.module.js:52-102`. |
+| `getTotalTax` | Line tax (zeroed when `tax_display_cart === 'incl'` to avoid double-counting) + fee tax + coupon tax adjustment. After save, switches to `server_order.total_tax`; if the server reports `0`, falls back to the **total/sub gap**, and beyond that to the **pre-save local computation** in excl mode (see [WC-silent fallback](#wc-silent-fallback)). | Headline "Tax" row. Direct port of legacy `Cart.module.js:52-102`. |
 
 The line-tax / total-tax split exists because in `incl` mode the Subtotal row already contains tax — adding line tax to the visible total would double-count. The "Including Tax" hint still needs the raw figure, so `getTotalLineTax` stays unconditional.
 
 **Coupon adjustment in `incl` mode.** Because `lineTax` is forced to `0` in `incl` mode, `couponTaxReduction = (discountAmount / subtotal) * 0 = 0`. This is mathematically correct: the incl-mode subtotal already bakes tax into the line price, so a coupon reducing `$X` simultaneously reduces both the price and the tax bundled inside it — no separate reduction line is needed.
 
-### WC-silent gap fallback
+### WC-silent fallback
 
-After `saveToServer` runs, WC sometimes returns the order with `total_tax = "0"` even though the line totals already bundle the tax. This happens when WC's `WC_Tax::find_rates()` can't resolve a tax rate from the order's location — typically a guest order with no billing address, where the standard rate has a country restriction that doesn't match the shop base.
+After `saveToServer` runs, WC sometimes returns the order with `total_tax = "0"` even when the cart was already showing tax. This happens when WC's `WC_Tax::find_rates()` can't resolve a tax rate from the order's location — typically a guest order with no billing address, where the standard rate has a country restriction that doesn't match the shop base.
 
-Without a fallback the cart would display `Subtotal $90.91` and `Order Total $100` with the Tax row hidden — a math contradiction visible to the cashier and a real loss of tax info in the printed receipt (`Tax Total $0.00`).
+Without a fallback the cart would lose the Tax row after save — a math contradiction visible to the cashier and a real loss of tax info in the printed receipt. `getTotalTax` recovers it through two layered fallbacks, applied only when `serverTax === 0`.
 
-`getTotalTax` handles this by deriving tax from the gap between `server.total` and the sum of non-tax components:
+**Layer 1 — total/sub gap.** Used when the raw line price already bundles the tax (incl-stored prices, `prices_include_tax = yes`). `server.total` carries the bundled tax even though `server.total_tax` doesn't break it out, so the gap surfaces it:
 
 ```ts
 gap = server.total - (subtotal − totalDiscount + totalFee + totalShipping)
-return gap > 0.01 ? gap : 0
+if (gap > 0.01) return gap
 ```
 
-Properties:
+**Layer 2 — pre-save local computation.** Used when the gap is `0` (no bundled tax to recover). The selector falls through to the same `lineTax + feeTax − couponTaxReduction` formula the cart uses pre-save, sourced from each item's `tax_amount` and the cached `available_tax` rates. In excl mode this restores the per-line tax that WC failed to add on top (the `prices_include_tax = no, tax_display_cart = excl` row, where the raw line price excludes tax and `server.total` equals `subtotal`). In incl mode `lineTax` is already zeroed to avoid double-counting, so only taxable fees pass through — `feeTax` correctly surfaces even when WC silently dropped it.
 
-- **Normal case** (server reports tax): `serverTax > 0`, used as-is. Gap path never triggers.
-- **WC-silent case** (server reports `0` but bundled tax exists): gap is positive, returned. Cashier sees `Subtotal + Tax = Order Total`.
-- **True zero-tax case** (server reports `0`, no bundled tax): gap is `0`, returned. No Tax row.
-- **`incl` mode**: `subtotal` already includes tax, so `subtotal == server.total` and gap is `0`. No Tax row, which is correct (tax is bundled into the displayed price).
+**`getTotal` partner change.** With `getTotalTax` synthesising tax, `getTotal` can no longer blindly return `server.total` (which would be lower than `subtotal + tax`). It now returns `Math.max(server.total, computed)`, where `computed = subtotal − discount + fee + shipping + totalTax`. `serverTax > 0` shortcircuits this to `server.total` (authoritative when WC resolved the rate).
 
-The print receipt mirrors the same logic in [`Home::processPayment`](./../src/frontend/pages/Home.tsx) when building `printdata.taxtotal`, so the printed `Tax Total` value matches the cart's Tax row in every case.
+Properties across the matrix:
 
-> **Note:** the gap fallback is a display safety net. The order saved in WC still has `total_tax = "0"` in the database — accounting / tax reports will not see this tax. The root fix is to ensure WC can resolve a rate (set a shop base country, or supply a billing country on the order). The fallback only prevents UI inconsistency.
+| `prices_include_tax` | `tax_display_cart` | When WC silently returns `total_tax=0` | Fallback used | Cart total |
+|---|---|---|---|---|
+| **no**  | **excl** | `server.total = $100` (raw, no tax added) | Layer 2 (local) | $110 (= 100 + 10) |
+| **no**  | **incl** | `server.total = $100` (raw, no tax added), `subtotal = $110` (display incl) | None — `getTotalTax = 0`, `getTotal` uses `max(server, computed) = $110` | $110 |
+| **yes** | **excl** | `server.total = $100` (raw incl tax), `subtotal = $90.91` (display excl) | Layer 1 (gap = $9.09) | $100 |
+| **yes** | **incl** | `server.total = $100` (raw incl tax), `subtotal = $100` (display incl) | None — gap is 0 and tax is bundled in the displayed line price | $100 |
+
+The print receipt builder in [`Home::processPayment`](./../src/frontend/pages/Home.tsx) reuses the cart's `total` and `totalTax` selectors directly — the printed `Tax Total` and `Order Total` match the cart row in every case.
+
+> **Note:** the fallbacks are a display safety net. The order saved in WC still has `total_tax = "0"` in the database — accounting / tax reports will not see this tax. The root fix is to ensure WC can resolve a rate (set a shop base country, or supply a billing country on the order). The fallback only prevents UI inconsistency, not the underlying loss of tax data on the saved order.
 
 **Extension point.** `getTotalTax` runs the result through the `wepos_cart_total_tax` filter. The payload is `{ lineTax, feeTax, couponTaxReduction }` — derived totals only, never the live store reference — so a filter callback cannot mutate cart state from inside the filter.
 
@@ -378,11 +384,11 @@ Setup: variable product with a variation `regular_price=$100`, 10% tax.
   - Expected — `getTotalTax` switches from the local computation to `server_order.total_tax`. If the snap is more than rounding noise, the local computation drifted from WC; reconcile by reading the row that fired in `getTotalTax` and comparing to WC's `tax_lines` in the saved order.
 
 - **Tax row hidden after Save to Server / Back to Sale (even though it was visible before)**
-  - WC returned `total_tax = "0"` because it couldn't resolve a tax rate from the order's location (guest order with no billing country, or shop base country missing). The selector now falls back to the [total/sub gap](#wc-silent-gap-fallback) so the row reappears — verify the cart Order Total truly equals `subtotal + fees + shipping − discounts + visible_tax`.
+  - WC returned `total_tax = "0"` because it couldn't resolve a tax rate from the order's location (guest order with no billing country, or shop base country missing). `getTotalTax` falls back first to the [total/sub gap](#wc-silent-fallback) (recovers bundled tax in `prices_include_tax = yes` rows) and then to the pre-save local computation (recovers excl-stored tax in `prices_include_tax = no, tax_display_cart = excl`). `getTotal` returns `max(server.total, computed)` so the cart row never drops below `subtotal + tax`.
   - Permanent fix: set a country on the shop base (`WooCommerce → Settings → General → Store address`), or supply a billing country on the order so `WC_Tax::find_rates()` can match. Otherwise the saved order will still record `total_tax = 0` in the database even though the UI displays the correct breakdown.
 
 - **Printed receipt shows `Tax Total $0.00` while Order Total includes tax**
-  - Same root cause as above — `parseFloat(orderResponse.total_tax)` returns `0`. The receipt builder in `Home::processPayment` now applies the same gap fallback as the selector, so `printdata.taxtotal` matches what the cashier sees in the cart.
+  - Same root cause as above — `parseFloat(orderResponse.total_tax)` returns `0`. The receipt builder in `Home::processPayment` now reads `totalTax` and `total` from the cart selectors directly, so it inherits both fallback layers and matches the cart row.
 
 
 ## References

--- a/docs/tax-handling.md
+++ b/docs/tax-handling.md
@@ -1,91 +1,85 @@
-## wePOS Tax Handling (Inclusive / Exclusive)
+# wePOS Tax Handling: Inclusive / Exclusive Reference
 
-- [Overview](#overview)
+This document explains how wePOS keeps cashier-visible totals consistent with WooCommerce's stored order totals across every combination of `woocommerce_prices_include_tax` and `woocommerce_tax_display_cart`. It also walks every scenario (simple, sale, variation) through the actual code paths so a future maintainer can re-verify any single row.
+
+- Target audience: wePOS contributors and integrators building on the cart store / product response
+- Applies to: wePOS ≥ 2.0.0
+
+
+## TL;DR
+
+- WooCommerce has two independent tax settings: one controls **how prices are stored**, the other controls **how prices are displayed**. Treat them as separate concerns.
+- Each cart item carries **two** price pairs: `regular_price` / `sale_price` (display, drive the UI) and `raw_regular_price` / `raw_sale_price` (raw, drive the order payload).
+- The server enriches every product / variation response with `regular_display_price`, `sales_display_price`, `tax_amount` — computed per-base-price (regular and sale separately).
+- Shop grid, cart row, and receipt always go through `pickRegularDisplayPrice` / `pickSaleDisplayPrice` so they show the same number.
+- Order payload sends `raw_*`, which means the same thing on both sides of the wire regardless of how the display is configured.
+- `tax_display_cart` and `available_tax` are store-wide reference data — preserved across `CLEAR_CART` and `HYDRATE_CART`.
+- `getTotalTax` falls back to `server_order.total_tax` after the order is saved.
+
+
+## Table of Contents
+
 - [The Two WooCommerce Settings](#the-two-woocommerce-settings)
-- [Display Layer vs Order Payload Layer](#display-layer-vs-order-payload-layer)
+- [Display vs Order Payload — the Split](#display-vs-order-payload--the-split)
 - [Server-Side: Product Response](#server-side-product-response)
 - [Client-Side: Hydration into the Store](#client-side-hydration-into-the-store)
 - [Cart Math in the Store](#cart-math-in-the-store)
 - [Order Payload Construction](#order-payload-construction)
 - [End-to-End Flow](#end-to-end-flow)
-- [Behavior Matrix](#behavior-matrix)
+- [Behavior Walkthrough — Every Combination](#behavior-walkthrough--every-combination)
+- [Sale Product — All Four Combinations](#sale-product--all-four-combinations)
+- [Variation Products — All Four Combinations](#variation-products--all-four-combinations)
 - [Edge Cases](#edge-cases)
 - [Testing](#testing)
+- [Troubleshooting](#troubleshooting)
+- [References](#references)
 
-### Overview
 
-WooCommerce exposes two independent tax settings that wePOS must honor when products are added to the cart and an order is saved through the REST API. The most common production bug in this area is conflating the two — using the *display* price (which respects the cart-display setting) as the *order payload* price (which is interpreted under the prices-include-tax setting). When the two settings disagree, the order total saved on the server no longer matches what the cashier saw on the screen.
+## The Two WooCommerce Settings
 
-wePOS resolves this by keeping the two concerns on separate fields of the cart item: display prices drive the UI, raw prices drive the order payload sent to `wc/v3/orders`.
+| Option key | Role |
+|---|---|
+| `woocommerce_prices_include_tax` | Declares whether `regular_price` / `sale_price` stored on a product is **tax-inclusive** or **tax-exclusive**. `WC_REST_Orders_V2_Controller::save_object` sets this flag on the order, and `calculate_totals()` interprets every posted `total` / `subtotal` under it. |
+| `woocommerce_tax_display_cart` | Display-only preference: show cart prices including or excluding tax. Independent of how prices are stored. |
 
-### The Two WooCommerce Settings
+`woocommerce_tax_display_shop` is **not used** by wePOS — the cashier UI always follows the cart-display setting.
 
-| Option key | UI label | Role |
-|---|---|---|
-| `woocommerce_prices_include_tax` | WooCommerce → Settings → Tax → *Prices entered with tax* | Declares whether the stored `regular_price` / `sale_price` on a product is **tax-inclusive** or **tax-exclusive**. This is the contract for the order REST API — `WC_REST_Orders_V2_Controller::save_object` flags the order via `$object->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) )` and then `calculate_totals()` interprets every posted `total` / `subtotal` under that flag. |
-| `woocommerce_tax_display_cart` | WooCommerce → Settings → Tax → *Display prices during cart and checkout* | A **display-only** preference: show cart prices including or excluding tax. Independent of how prices are stored. |
-| `woocommerce_tax_display_shop` | WooCommerce → Settings → Tax → *Display prices in the shop* | Display-only preference for the shop catalog. **wePOS does not use this setting** — the POS uses the cart display setting for the cashier UI. |
 
-> The cart display setting changes what number the cashier sees. The prices-include-tax setting changes how WooCommerce *interprets* a posted number on the order endpoint. These are independent levers and they may disagree.
+## Display vs Order Payload — the Split
 
-### Display Layer vs Order Payload Layer
-
-The cart item carries **two** parallel price pairs:
+Each cart item carries **two** price pairs:
 
 | Field on `POSCartItem` | Source | Used by |
 |---|---|---|
-| `regular_price` / `sale_price` | Server-computed display price (`regular_display_price` / `sales_display_price` injected by [`Manager::product_response`](../includes/REST/Manager.php#L63)) | Cart UI — subtotal row, per-line price, strikethrough on sale |
-| `raw_regular_price` / `raw_sale_price` | Untouched `product.regular_price` / `product.sale_price` from WC | Order payload only — passed as `line_items[].total` / `subtotal` so WC interprets them against `woocommerce_prices_include_tax` |
+| `regular_price` / `sale_price` | Server-computed display price (`regular_display_price` / `sales_display_price` from [`Manager::product_response`](./../includes/REST/Manager.php#L63)) | Cart UI — subtotal, per-line price, sale strikethrough |
+| `raw_regular_price` / `raw_sale_price` | Untouched `product.regular_price` / `product.sale_price` | Order payload — `line_items[].total` / `subtotal` interpreted against `woocommerce_prices_include_tax` |
 
-This separation is the entire fix. The display layer math (subtotal, per-line tax hint, total tax row) is unchanged from the legacy Vue UI. The order layer now sends a value that means the same thing on both sides of the wire.
+This separation is the fix. Display math is unchanged from the legacy Vue UI. The order payload now sends a value that means the same thing on both sides of the wire.
 
-Type declarations live in [`src/frontend/types/index.ts`](../src/frontend/types/index.ts) (`POSCartItem`).
+Type lives in [`types/index.ts`](./../src/frontend/types/index.ts) (`POSCartItem`).
 
-### Server-Side: Product Response
 
-[`Manager::product_response`](../includes/REST/Manager.php#L63) is hooked into the product REST response and enriches each product with three tax-aware fields:
+## Server-Side: Product Response
+
+[`Manager::product_response`](./../includes/REST/Manager.php#L63) enriches each product (and variation) REST response with three tax-aware fields:
 
 | Output field | Computed as | Notes |
 |---|---|---|
-| `regular_display_price` | `regular_excl_tax + regular_tax` when `tax_display_cart === 'incl'`, otherwise `regular_excl_tax` | Always derived from the **regular** price base |
-| `sales_display_price` | `sale_excl_tax + sale_tax` when `tax_display_cart === 'incl'`, otherwise `sale_excl_tax` | Always derived from the **sale** price base; `0` when the product is not on sale |
-| `tax_amount` | `sale_tax` when on sale, otherwise `regular_tax` | Drives the per-line tax label and the "Including Tax" hint client-side |
+| `regular_display_price` | `regular_excl_tax + regular_tax` when `tax_display_cart === 'incl'`, otherwise `regular_excl_tax` | Always derived from the regular price base |
+| `sales_display_price` | `sale_excl_tax + sale_tax` when `tax_display_cart === 'incl'`, otherwise `sale_excl_tax` | Derived from the sale price; `0` when not on sale |
+| `tax_amount` | `sale_tax` when on sale, otherwise `regular_tax` | Drives the per-line tax label and the "Including Tax" hint |
 
-**Why compute tax per-price.** WooCommerce's `wc_get_price_including_tax( $product )` returns the *effective* price (sale price when on sale), so deriving a single `$tax_amount` from it and adding the same amount to both the regular and sale display lines produces the wrong number on the regular row of an on-sale product. The function computes `regular_tax` and `sale_tax` from their own base prices independently.
+**Why compute tax per-price.** `wc_get_price_including_tax( $product )` returns the *effective* price (sale price when on sale), so deriving one `$tax_amount` from it and adding the same amount to both the regular and sale lines would mis-tax the regular row on an on-sale product. The function computes `regular_tax` and `sale_tax` from their own base prices.
 
-**Why these getters honor `prices_include_tax`.** Both `wc_get_price_excluding_tax()` and `wc_get_price_including_tax()` consult `woocommerce_prices_include_tax` internally to interpret the input `price` argument. Removing the explicit `if ( 'no' === $tax_calculations )` branch from the previous implementation did not skip that logic — it pushed responsibility to WooCommerce, which already knew. The old code's outer `if/else` arms were textually identical, so the branch was dead code.
+**Why these getters honor `prices_include_tax`.** Both `wc_get_price_excluding_tax()` and `wc_get_price_including_tax()` consult `woocommerce_prices_include_tax` internally to interpret the input `price` argument. The previous outer `if/else` on `$tax_calculations` was textually identical in both arms — dead code, dropped.
 
-```mermaid
-flowchart TD
-    A["Product REST request"] --> B["WC default product_response"]
-    B --> C["Manager::product_response filter"]
-    C --> D["Read woocommerce_tax_display_cart"]
-    D --> E["wc_get_price_excluding_tax(regular_price)"]
-    D --> F["wc_get_price_including_tax(regular_price)"]
-    D --> G["wc_get_price_excluding_tax(sale_price)"]
-    D --> H["wc_get_price_including_tax(sale_price)"]
-    E --> I["regular_tax = incl - excl"]
-    F --> I
-    G --> J["sale_tax = incl - excl"]
-    H --> J
-    I --> K["regular_display_price"]
-    J --> L["sales_display_price"]
-    I --> M{"is_on_sale?"}
-    J --> M
-    M -- Yes --> N["tax_amount = sale_tax"]
-    M -- No --> O["tax_amount = regular_tax"]
-    K --> P["Augmented JSON response"]
-    L --> P
-    N --> P
-    O --> P
-```
 
-### Client-Side: Hydration into the Store
+## Client-Side: Hydration into the Store
 
-On POS load, [`pages/Home.tsx`](../src/frontend/pages/Home.tsx) runs two effects that synchronize the cart store with WooCommerce settings:
+On POS load, [`pages/Home.tsx`](./../src/frontend/pages/Home.tsx) runs two effects:
 
-1. Mirror `settings.woo_tax` → `cart.tax_display_cart` via [`setTaxDisplayMode`](../src/frontend/store/cart/actions.ts#L139).
-2. Fetch `/wepos/v1/taxes` and dispatch [`setAvailableTax`](../src/frontend/store/cart/actions.ts#L146).
+1. Mirror `settings.woo_tax.wc_tax_display_cart` into the store via [`setTaxDisplayMode`](./../src/frontend/store/cart/actions.ts#L139).
+2. Fetch `/wepos/v1/taxes` and dispatch [`setAvailableTax`](./../src/frontend/store/cart/actions.ts#L146).
 
 When a product is added to the cart, the cart item is hydrated from the product response:
 
@@ -97,27 +91,38 @@ raw_sale_price:    toFiniteNumber(product.sale_price),
 tax_amount:        toFiniteNumber(product.tax_amount),
 ```
 
-Variations use the same pattern in [`ProductVariationSelector.tsx`](../src/frontend/components/ProductVariationSelector.tsx) and fall back to the parent product's `tax_amount` when the variation does not report its own. Misc/custom products (cashier-entered) set `raw_*` equal to the entered price — there is no display/raw distinction because WC interprets that single value under `prices_include_tax`.
+Variations use the same pattern in [`ProductVariationSelector.tsx`](./../src/frontend/components/ProductVariationSelector.tsx) and fall back to the parent product's `tax_amount` via `firstPresentNumber( variation.tax_amount, product.tax_amount )` when the variation does not report its own. Misc/custom products set `raw_*` equal to the entered price — there is no display/raw distinction since WC interprets that single value under `prices_include_tax`.
 
-Helpers: [`pickRegularDisplayPrice`](../src/frontend/utils/helpers.ts#L191), [`pickSaleDisplayPrice`](../src/frontend/utils/helpers.ts#L198), [`toFiniteNumber`](../src/frontend/utils/helpers.ts#L163), [`firstPresentNumber`](../src/frontend/utils/helpers.ts#L170).
+**The shop product grid uses the same display-price helpers.** [`ProductGridView`](./../src/frontend/components/ProductGridView.tsx), [`ProductListView`](./../src/frontend/components/ProductListView.tsx), and the search dropdown ([`SearchBar`](./../src/frontend/components/SearchBar.tsx)) all render `pickRegularDisplayPrice` / `pickSaleDisplayPrice` — not raw `product.regular_price`. Without this, the grid would show the *stored* price while the cart row shows the *cart-display* price, and those differ in two of the four matrix rows (rows 2 and 3 below). The product grid, the cart, and the receipt always agree on the number for any given product.
 
-### Cart Math in the Store
+Helpers: [`pickRegularDisplayPrice`](./../src/frontend/utils/helpers.ts#L191), [`pickSaleDisplayPrice`](./../src/frontend/utils/helpers.ts#L198), [`toFiniteNumber`](./../src/frontend/utils/helpers.ts#L163), [`firstPresentNumber`](./../src/frontend/utils/helpers.ts#L170).
 
-Two selectors in [`store/cart/selectors.ts`](../src/frontend/store/cart/selectors.ts) drive every tax surface in the cart UI:
+**Reference-data invariant.** `tax_display_cart` and `available_tax` are store-wide reference data — not part of a cart snapshot. Both `HYDRATE_CART` (cart restore) and `CLEAR_CART` (void / new sale) preserve them, so an empty cart still has the rates needed to compute fee/coupon tax once items are re-added. Mutate them only through `setTaxDisplayMode` / `setAvailableTax`.
 
-| Selector | Returns | Purpose |
+
+## Cart Math in the Store
+
+Three selectors in [`store/cart/selectors.ts`](./../src/frontend/store/cart/selectors.ts) cover every tax surface:
+
+| Selector | Returns | Used by |
 |---|---|---|
-| `getTotalLineTax` | `Σ \|tax_amount × qty\|` over every line | Raw line tax, **never zeroed**. Powers the "Including Tax" hint under the Subtotal row. |
-| `getTotalTax` | Line tax (zeroed when `tax_display_cart === 'incl'` so it isn't double-counted in the visible total) + fee tax + coupon tax adjustment. Falls back to `server_order.total_tax` once the order is saved. | The headline "Tax" row in the cart. Direct port of the legacy Vue `Cart.module.js:52-102`. |
+| `getTaxDisplayMode` | `'incl' \| 'excl'` from the store | Cart UI label switches (single source of truth — Cart components must not re-read from `settings`) |
+| `getTotalLineTax` | `Σ tax_amount × qty` over every line | "Including Tax" hint under Subtotal. Never zeroed, even in `incl` mode. |
+| `getTotalTax` | Line tax (zeroed when `tax_display_cart === 'incl'` to avoid double-counting) + fee tax + coupon tax adjustment. Falls back to `server_order.total_tax` once the order is saved. | Headline "Tax" row. Direct port of legacy `Cart.module.js:52-102`. |
 
-The split exists because the Subtotal row in `incl` mode already includes tax — adding line tax to the visible total again would double-count. The "Including Tax" hint still needs the raw figure, so `getTotalLineTax` stays unconditional.
+The line-tax / total-tax split exists because in `incl` mode the Subtotal row already contains tax — adding line tax to the visible total would double-count. The "Including Tax" hint still needs the raw figure, so `getTotalLineTax` stays unconditional.
 
-### Order Payload Construction
+**Coupon adjustment in `incl` mode.** Because `lineTax` is forced to `0` in `incl` mode, `couponTaxReduction = (discountAmount / subtotal) * 0 = 0`. This is mathematically correct: the incl-mode subtotal already bakes tax into the line price, so a coupon reducing `$X` simultaneously reduces both the price and the tax bundled inside it — no separate reduction line is needed.
 
-[`Home::buildOrderPayload`](../src/frontend/pages/Home.tsx#L883) builds the body sent to `wc/v3/orders`. The critical change: `line_items[].total` and `subtotal` are computed from `raw_*` prices, not the display prices.
+**Extension point.** `getTotalTax` runs the result through the `wepos_cart_total_tax` filter. The payload is `{ lineTax, feeTax, couponTaxReduction }` — derived totals only, never the live store reference — so a filter callback cannot mutate cart state from inside the filter.
+
+
+## Order Payload Construction
+
+[`Home::buildOrderPayload`](./../src/frontend/pages/Home.tsx#L883) builds the body sent to `wc/v3/orders`. The critical change: `line_items[].total` and `subtotal` come from `raw_*`, not display prices.
 
 ```ts
-const rawRegular = item.raw_regular_price ?? item.regular_price; // fallback for legacy in-memory carts
+const rawRegular = item.raw_regular_price ?? item.regular_price; // legacy in-memory carts
 const rawSale    = item.raw_sale_price    ?? item.sale_price;
 const unitPrice  = item.on_sale ? rawSale : rawRegular;
 
@@ -125,9 +130,10 @@ lineItem.subtotal = (unitPrice * item.quantity).toFixed(2);
 lineItem.total    = (unitPrice * item.quantity).toFixed(2);
 ```
 
-Misc/custom products post their cashier-entered `price` directly — WC interprets it against `prices_include_tax` exactly like any other product. The display path (cart UI subtotal, per-line price, total tax row) keeps reading `regular_price` / `sale_price` and is unaffected.
+Misc/custom products post their cashier-entered `price` directly — WC interprets it against `prices_include_tax` like any other product. The cart UI (subtotal, per-line price, total tax row) keeps reading `regular_price` / `sale_price` and is unaffected.
 
-### End-to-End Flow
+
+## End-to-End Flow
 
 ```mermaid
 sequenceDiagram
@@ -149,45 +155,225 @@ sequenceDiagram
     Order-->>POS: server_order.total_tax (selectors switch over to this)
 ```
 
-### Behavior Matrix
 
-For each combination of (`prices_include_tax` × `tax_display_cart`), the cashier total must equal the saved order total.
+## Behavior Walkthrough — Every Combination
 
-| `prices_include_tax` | `tax_display_cart` | Cart UI shows | Order saved as |
-|---|---|---|---|
-| no  | excl | $100 + $10 tax = $110 | $110 |
-| no  | **incl** | $110 ("Including Tax" hint) | $110 |
-| yes | **excl** | $90.91 + $9.09 tax = $100 | $100 |
-| yes | incl | $100 ("Including Tax" hint) | $100 |
+All combinations were traced end-to-end through the current code. Setup is the same throughout: **WooCommerce → Settings → Tax → 10% standard rate, `$100` regular price**. Each row of the table is reproducible from the linked file.
 
-The middle two rows are where the two settings disagree — those are the rows the fix targets.
+Matrix summary:
 
-#### Sale-product secondary fix
+| `prices_include_tax` | `tax_display_cart` | Shop grid | Cart row | Cart total | Saved order |
+|---|---|---|---|---|---|
+| **no**  | **excl** | $100 | $100 + $10 tax | **$110** | **$110** ✓ |
+| **no**  | **incl** | $110 | $110 ("Including Tax") | **$110** | **$110** ✓ |
+| **yes** | **excl** | $90.91 | $90.91 + $9.09 tax | **$100** | **$100** ✓ |
+| **yes** | **incl** | $100 | $100 ("Including Tax") | **$100** | **$100** ✓ |
 
-`regular=$100, sale=$80, tax=10%, prices_include_tax=no, tax_display_cart=incl`:
+Shop grid and cart row always agree. Cart total always equals the saved order total.
 
-| Field | Before fix | After fix |
+### Scenario A — `prices_include_tax = no, tax_display_cart = excl`
+
+Stored value is tax-exclusive; display is tax-exclusive. The classic "sticker price + tax at checkout" model used in the US.
+
+| Stage | Code | Result |
 |---|---|---|
-| `regular_display_price` | $108 (sale tax added to regular) | $110 |
-| `sales_display_price` | $88 | $88 |
-| Per-row tax shown | $8 on both rows | $10 (regular) / $8 (sale) |
+| WC DB | `regular_price` | `"100"` (means $100 excl) |
+| Server response | [`Manager::product_response`](./../includes/REST/Manager.php#L84) — `regular_excl_tax=100, regular_incl_tax=110, regular_tax=10, show_incl_tax=false` | `regular_display_price="100.00"`, `tax_amount="10.00"` |
+| Shop grid | [`pickRegularDisplayPrice(product)`](./../src/frontend/utils/helpers.ts#L191) | renders **$100** |
+| Add to cart | [`Home.tsx#L474`](./../src/frontend/pages/Home.tsx#L474) | `regular_price=100, raw_regular_price=100, tax_amount=10, on_sale=false` |
+| `getSubtotal` | `regular_price × qty` | `100` |
+| `getTotalLineTax` | `tax_amount × qty` (raw, for hint) | `10` |
+| `getTotalTax` | excl mode → `lineTax` included | `10` |
+| `getTotal` | `subtotal + totalTax` | `110` |
+| Cart UI | subtotal $100; per-line `+ tax $10`; "Tax $10"; Checkout `$110` | $110 |
+| Order payload | `line_items[0].total = (raw × qty).toFixed(2)` = `"100.00"` | $100 sent |
+| WC interpretation | `prices_include_tax=no` ⇒ posted `total` is excl ⇒ add 10% | `total=$110, total_tax=$10` |
 
-### Edge Cases
+**Why correct vs WooCommerce.** WC native checkout in this config also shows `$100 + $10 tax = $110`. wePOS sends the same raw `$100` line item, and WC's own `calculate_totals()` applies the same `prices_include_tax=no` flag — identical math.
 
-- **Empty sale price.** `$sale_price === ''` short-circuits `sale_excl_tax` / `sale_incl_tax` to `0.0`. Without this guard, `wc_get_price_excluding_tax( $product, [ 'price' => '' ] )` would coerce to `0` *after* a tax computation and emit `E_WARNING` on some PHP versions.
-- **Variation `tax_amount` missing.** [`ProductVariationSelector.tsx`](../src/frontend/components/ProductVariationSelector.tsx) falls back to the parent product's `tax_amount` via `firstPresentNumber( variation.tax_amount, product.tax_amount )` so the per-line label still renders.
-- **Legacy in-memory carts.** Cart items hydrated before this build do not have `raw_*` fields. `buildOrderPayload` falls back to `regular_price` / `sale_price` so existing carts keep working — they will save with the old (pre-fix) behavior until the cart is refreshed.
-- **Server round-trip.** After `wc/v3/orders` returns, `getTotalTax` switches from local computation to `server_order.total_tax`. Any subsequent UI render reflects WC's authoritative number, not the local approximation.
-- **Misc/custom products.** No display/raw split — the cashier enters a single price and WC interprets it under `prices_include_tax`. The cart UI shows the same number the cashier typed.
+### Scenario B — `prices_include_tax = no, tax_display_cart = incl`
 
-### Testing
+Stored excl, displayed incl. Common in the UK / EU where stickers must show the all-in price even though the DB stores excl. **This is one of the two rows where the fix is load-bearing.**
+
+| Stage | Code | Result |
+|---|---|---|
+| WC DB | `regular_price` | `"100"` (excl) |
+| Server response | `show_incl_tax=true` → `regular_display = regular_excl_tax + regular_tax = 100 + 10` | `regular_display_price="110.00"`, `tax_amount="10.00"` |
+| Shop grid | `pickRegularDisplayPrice` | **$110** |
+| Add to cart | display→`regular_price=110`, raw→`raw_regular_price=100`, `tax_amount=10` | — |
+| `getSubtotal` | `110 × 1` | `110` |
+| `getTotalLineTax` | `10` (unconditional for the hint) | `10` |
+| `getTotalTax` | incl mode → `lineTax = 0` (would double-count) | `0` |
+| `getTotal` | `110 + 0` | `110` |
+| Cart UI | subtotal **$110** + "Including Tax" hint; per-line `incl. tax $10`; **no separate Tax row**; Checkout `$110` | $110 |
+| Order payload | `total = raw × qty = "100.00"` | $100 sent |
+| WC interpretation | `prices_include_tax=no` ⇒ posted `$100` is excl ⇒ + 10% | `total=$110, total_tax=$10` |
+
+**Why correct vs WooCommerce.** WC frontend in this config also shows `$110 (incl. $10 tax)` in the cart. The trap is that the cart shows `$110` but the *stored* price is `$100`. Sending `$110` to the order endpoint would tell WC "tax-exclusive $110" → final `$121` — a `$11` overcharge. wePOS sends `$100` raw, matching what WC stored, so `calculate_totals()` produces `$110` exactly.
+
+### Scenario C — `prices_include_tax = yes, tax_display_cart = excl`
+
+Stored incl, displayed excl. Used when a merchant prefers to store tax-inclusive prices but show breakdown at checkout. **The second load-bearing row.**
+
+| Stage | Code | Result |
+|---|---|---|
+| WC DB | `regular_price` | `"100"` (already includes $9.09 tax) |
+| Server response | `regular_excl_tax = wc_get_price_excluding_tax($100) ≈ 90.91`; `regular_tax = 100 - 90.91 = 9.09`; `show_incl_tax=false` → `regular_display = 90.91` | `regular_display_price="90.91"`, `tax_amount="9.09"` |
+| Shop grid | `pickRegularDisplayPrice` | **$90.91** |
+| Add to cart | display→`regular_price=90.91`, raw→`raw_regular_price=100`, `tax_amount=9.09` | — |
+| `getSubtotal` | `90.91 × 1` | `90.91` |
+| `getTotalLineTax` | `9.09` | `9.09` |
+| `getTotalTax` | excl mode → `lineTax = 9.09` | `9.09` |
+| `getTotal` | `90.91 + 9.09` | `100` |
+| Cart UI | subtotal $90.91; per-line `+ tax $9.09`; "Tax $9.09"; Checkout `$100` | $100 |
+| Order payload | `total = raw × qty = "100.00"` | $100 sent |
+| WC interpretation | `prices_include_tax=yes` ⇒ posted `$100` already includes tax | `total=$100, total_tax=$9.09` |
+
+**Why correct vs WooCommerce.** WC native this config shows `$90.91 + $9.09 = $100`. The trap is that *display* is `$90.91`, but sending `$90.91` to the order with `prices_include_tax=yes` would tell WC "$90.91 is already incl" → final `$90.91`, breaking the cashier's expectation by `$9.09`. wePOS sends the stored `$100` raw — WC keeps it as-is — total reconciles.
+
+### Scenario D — `prices_include_tax = yes, tax_display_cart = incl`
+
+Stored incl, displayed incl. The simplest case — display equals what's stored.
+
+| Stage | Code | Result |
+|---|---|---|
+| WC DB | `regular_price` | `"100"` (incl) |
+| Server response | `regular_excl=90.91, regular_tax=9.09, show_incl_tax=true` → `regular_display = 90.91 + 9.09 = 100` | `regular_display_price="100.00"`, `tax_amount="9.09"` |
+| Shop grid | `pickRegularDisplayPrice` | **$100** |
+| Add to cart | display→`regular_price=100`, raw→`raw_regular_price=100`, `tax_amount=9.09` | — |
+| `getSubtotal` | `100` | `100` |
+| `getTotalLineTax` | `9.09` (for hint) | `9.09` |
+| `getTotalTax` | incl mode → `lineTax = 0` | `0` |
+| `getTotal` | `100` | `100` |
+| Cart UI | subtotal $100 + "Including Tax" hint; per-line `incl. tax $9.09`; **no separate Tax row**; Checkout `$100` | $100 |
+| Order payload | `total = raw × qty = "100.00"` | $100 sent |
+| WC interpretation | `prices_include_tax=yes` ⇒ keep as-is | `total=$100, total_tax=$9.09` |
+
+**Why correct vs WooCommerce.** WC native cart shows `$100 (incl. $9.09 tax)`. wePOS shows the same and sends the same `$100` raw — no transformation needed in either direction.
+
+
+## Sale Product — All Four Combinations
+
+Setup: `regular_price=$100, sale_price=$80, on_sale=true`, 10% tax.
+
+Manager.php computes **regular_tax** and **sale_tax** from their own base prices (this is the sale-product secondary fix — the legacy code used a single `tax_amount` derived from `wc_get_price_including_tax($product)`, which silently returned the sale price for an on-sale product and mis-taxed the strikethrough regular row). `tax_amount` is the effective tax: `sale_tax` when on sale, `regular_tax` otherwise.
+
+| Combo | regular_excl / sale_excl | regular_tax / sale_tax | regular_display | sales_display | `tax_amount` | Shop / cart shows | Cart total | Saved |
+|---|---|---|---|---|---|---|---|---|
+| **no, excl** | 100 / 80 | 10 / 8 | 100 | 80 | 8 | ~~$100~~ **$80** + tax $8 | **$88** | **$88** ✓ |
+| **no, incl** | 100 / 80 | 10 / 8 | 110 | 88 | 8 | ~~$110~~ **$88** (incl) | **$88** | **$88** ✓ |
+| **yes, excl** | 90.91 / 72.73 | 9.09 / 7.27 | 90.91 | 72.73 | 7.27 | ~~$90.91~~ **$72.73** + tax $7.27 | **$80** | **$80** ✓ |
+| **yes, incl** | 90.91 / 72.73 | 9.09 / 7.27 | 100 | 80 | 7.27 | ~~$100~~ **$80** (incl) | **$80** | **$80** ✓ |
+
+The strikethrough row is `pickRegularDisplayPrice(product)` and the active row is `pickSaleDisplayPrice(product)` — both per-base-price values, so the two rows match the merchant's mental model in every combo. Order payload uses `raw_sale_price = $80` (because `on_sale=true`), and WC interprets it under `prices_include_tax` exactly like a non-sale product.
+
+**Why correct vs WooCommerce.** WC frontend renders sale products with the same strikethrough-regular / active-sale pattern using `wc_get_price_to_display`, which itself routes through `wc_get_price_excluding_tax` / `wc_get_price_including_tax` per base price. Manager.php replicates that calculation server-side so the POS receives the same numbers WC would render on the storefront.
+
+
+## Variation Products — All Four Combinations
+
+Setup: variable product with a variation `regular_price=$100`, 10% tax.
+
+`Manager::product_response` is hooked for both `woocommerce_rest_prepare_product_object` **and** `woocommerce_rest_prepare_product_variation_object` ([`Manager.php#L36`](./../includes/REST/Manager.php#L36)), so every variation in `product.variations` carries its own `regular_display_price` / `sales_display_price` / `tax_amount`. The variable parent's own `regular_display_price` is `0` (parent has no price of its own) — never used.
+
+| Combo | Variation `regular_display_price` | `tax_amount` | Shop grid (price range or single) | After variation picked, cart row | Cart total | Saved order |
+|---|---|---|---|---|---|---|
+| **no, excl** | 100 | 10 | $100 | $100 + tax $10 | **$110** | **$110** ✓ |
+| **no, incl** | 110 | 10 | $110 ("Including Tax") | $110 (incl) | **$110** | **$110** ✓ |
+| **yes, excl** | 90.91 | 9.09 | $90.91 | $90.91 + tax $9.09 | **$100** | **$100** ✓ |
+| **yes, incl** | 100 | 9.09 | $100 ("Including Tax") | $100 (incl) | **$100** | **$100** ✓ |
+
+[`ProductGridView.getVariablePriceRange`](./../src/frontend/components/ProductGridView.tsx) iterates `product.variations` and runs `pickSaleDisplayPrice` / `pickRegularDisplayPrice` per variation, so a multi-variation product shows e.g. `"$80 – $120"` using each variation's own display price.
+
+[`ProductVariationSelector.handleAddVariation`](./../src/frontend/components/ProductVariationSelector.tsx#L67) hydrates the cart item from the chosen variation using the same helpers (`pickRegularDisplayPrice`, `pickSaleDisplayPrice`, raw fields, `tax_amount` with fallback `firstPresentNumber(variation.tax_amount, product.tax_amount)`). The cart row, the order payload, and the saved total then behave exactly as the simple-product scenarios above.
+
+### Sale variation, combo B (`no, incl`) — worked example
+
+| Stage | Result |
+|---|---|
+| Variation stored: `regular_price=100, sale_price=80, on_sale=true` | — |
+| Manager.php on variation: `regular_excl=100, regular_tax=10, regular_display=110`; `sale_excl=80, sale_tax=8, sale_display=88`; `tax_amount=8` (on sale) | — |
+| Shop grid (price range) | `"$88"` (or range with siblings) |
+| Pick variation → cart | `regular_price=110, sale_price=88, raw_regular=100, raw_sale=80, tax_amount=8, on_sale=true` |
+| Cart row | ~~$110~~ **$88** with `incl. tax $8` |
+| `getSubtotal` | `88` |
+| `getTotalTax` (incl) | `0` |
+| `getTotal` | `88` |
+| Order payload | `total = rawSale × qty = "80.00"` |
+| WC interpretation | `prices_include_tax=no` → $80 + 10% = `$88, total_tax=$8` |
+| Cart $88 vs saved $88 | ✓ |
+
+**Why correct vs WooCommerce.** Native WC variable products use the same per-variation pricing on the storefront. Each variation is a distinct WC_Product with its own `regular_price` / `sale_price`. wePOS treats each one identically — the per-variation `tax_amount` is computed from that variation's own base prices, not from the parent. The parent fallback exists only as a safety net for variations that somehow lack a computed `tax_amount` field.
+
+
+## Edge Cases
+
+- **Empty sale price.** `'' === $sale_price` short-circuits `sale_excl_tax` / `sale_incl_tax` to `0.0` ([`Manager.php#L95`](./../includes/REST/Manager.php#L95)) — avoids an `E_WARNING` from `wc_get_price_excluding_tax` on some PHP versions.
+- **Variation `tax_amount` missing.** `firstPresentNumber( variation.tax_amount, product.tax_amount )` falls back to the parent product so the per-line label still renders.
+- **Legacy in-memory carts.** Items added before this build have no `raw_*` fields. `buildOrderPayload` falls back to `regular_price` / `sale_price` so existing carts keep working until refreshed.
+- **Server round-trip.** Once `wc/v3/orders` returns, `getTotalTax` switches to `server_order.total_tax`. Subsequent UI renders reflect WC's authoritative number, not the local approximation.
+- **Misc/custom products.** No display/raw split — cashier types one price; WC interprets it under `prices_include_tax`. The cart UI shows the same number the cashier typed.
+- **Tax fetch / restore race.** If `restoreServerCart` finishes before `/wepos/v1/taxes` resolves, fee/coupon tax adjustment is `0` until rates arrive. Self-corrects: `HYDRATE_CART` preserves `available_tax`, and once `setAvailableTax` fires, selectors recompute.
+
+
+## Testing
 
 1. WooCommerce → Settings → Tax → set a 10% standard rate.
 2. For each of the four `prices_include_tax × tax_display_cart` permutations:
-   - Add the $100 regular product.
-   - Confirm cart UI total.
-   - Place the order, open it in `wp-admin → Orders`, confirm the saved total equals the cart total.
-3. Sale-product check: add a `regular=$100, sale=$80` product under `prices_include_tax=no, tax_display_cart=incl`. Verify the strikethrough reads **$110** and the active line reads **$88**.
-4. Variations: add a variable product, confirm the variation's `tax_amount` (or parent fallback) labels the row.
-5. Misc/custom item: add a cashier-entered $50 product. The saved order total must equal `$50` in `excl` storage, and `$50` final-inclusive in `yes` storage.
-6. Fees and coupons: add a taxable percent fee and a taxable coupon. Confirm the total tax row reflects them before the order is saved (local computation) and continues to match after save (server response).
+   1. Add the $100 regular product.
+   2. Confirm the cart UI total.
+   3. Place the order; open it in `wp-admin → Orders` and confirm the saved total equals the cart total.
+3. **Sale product**: under `prices_include_tax=no, tax_display_cart=incl`, add `regular=$100, sale=$80`. Verify strikethrough reads `$110` and the active line reads `$88`.
+4. **Variations**: add a variable product. Confirm the variation's `tax_amount` (or parent fallback) labels the row.
+5. **Misc/custom item**: add a cashier-entered `$50` product. Saved order total must equal `$50` in `prices_include_tax=no` and `$50` final-inclusive in `prices_include_tax=yes`.
+6. **Fees and coupons**: add a taxable percent fee and a taxable coupon. Total tax row must reflect them before save (local computation) and continue to match after save (server response).
+7. **Void / new sale**: clear the cart, then add a taxable product. Fee/coupon tax must still compute — `CLEAR_CART` preserves the tax rate table.
+
+
+## Troubleshooting
+
+- **Cashier total does not match saved order total**
+  - Confirm `Manager::product_response` is registered (`woocommerce_rest_prepare_product_object` + `woocommerce_rest_prepare_product_variation_object`) and the response carries `regular_display_price`, `sales_display_price`, `tax_amount`.
+  - Inspect a cart item in DevTools: it must have both `regular_price` / `sale_price` *and* `raw_regular_price` / `raw_sale_price`. If `raw_*` is missing, the cart is from a stale build — clear it and re-add.
+  - Verify the `buildOrderPayload` output: `line_items[].total` must equal `(raw * qty).toFixed(2)`, never the display price.
+
+- **Shop grid and cart row show different prices**
+  - All three surfaces (`ProductGridView`, `ProductListView`, `SearchBar`) must route prices through `pickRegularDisplayPrice` / `pickSaleDisplayPrice`. Anything calling `formatPrice(product.regular_price)` directly will desync in the `no, incl` and `yes, excl` combos.
+
+- **Fee or coupon tax is `0` until the order is saved**
+  - The `/wepos/v1/taxes` fetch (in `Home.tsx`) has not resolved yet, or the request failed. Check the console for `wePOS: failed to fetch tax rates` and verify the `TaxController` route is registered.
+  - In `incl` mode, coupon tax reduction is intentionally `0` — see the [Coupon adjustment in `incl` mode](#cart-math-in-the-store) note. The reduction is bundled into the line price.
+
+- **Sale strikethrough shows the wrong number**
+  - The strikethrough row uses `pickRegularDisplayPrice`; the active row uses `pickSaleDisplayPrice`. If both rows show the sale price, Manager.php's per-base-price computation may have regressed — verify `regular_excl_tax` and `sale_excl_tax` are computed separately.
+
+- **Variation row has no `tax_amount` label**
+  - Variations should fall back to `product.tax_amount` via `firstPresentNumber(variation.tax_amount, product.tax_amount)` in `ProductVariationSelector.tsx`. If the label is still missing, both the variation and the parent product lack `tax_amount` — check that `Manager::product_response` is hooked for the variation filter, not only the product filter.
+
+- **Cart total snaps to a different number after "Save to Server"**
+  - Expected — `getTotalTax` switches from the local computation to `server_order.total_tax`. If the snap is more than rounding noise, the local computation drifted from WC; reconcile by reading the row that fired in `getTotalTax` and comparing to WC's `tax_lines` in the saved order.
+
+
+## References
+
+- Backend
+  - [`includes/REST/Manager.php`](./../includes/REST/Manager.php) — `product_response` filter, registers the variation hook
+  - [`includes/REST/TaxController.php`](./../includes/REST/TaxController.php) — `/wepos/v1/taxes` endpoint
+- Frontend — store
+  - [`src/frontend/store/cart/selectors.ts`](./../src/frontend/store/cart/selectors.ts) — `getSubtotal`, `getTotalLineTax`, `getTotalTax`, `getTaxDisplayMode`, `wepos_cart_total_tax` filter
+  - [`src/frontend/store/cart/reducer.ts`](./../src/frontend/store/cart/reducer.ts) — `HYDRATE_CART` / `CLEAR_CART` preserve `available_tax` and `tax_display_cart`
+  - [`src/frontend/store/cart/actions.ts`](./../src/frontend/store/cart/actions.ts) — `setTaxDisplayMode`, `setAvailableTax`
+  - [`src/frontend/store/cart/types.ts`](./../src/frontend/store/cart/types.ts) — `CartState`, `TaxRate`
+- Frontend — UI
+  - [`src/frontend/pages/Home.tsx`](./../src/frontend/pages/Home.tsx) — `setTaxDisplayMode` / `setAvailableTax` effects, `buildOrderPayload`, add-to-cart hydration
+  - [`src/frontend/components/Cart.tsx`](./../src/frontend/components/Cart.tsx) — cart UI, reads `getTaxDisplayMode`
+  - [`src/frontend/components/ProductGridView.tsx`](./../src/frontend/components/ProductGridView.tsx) / [`ProductListView.tsx`](./../src/frontend/components/ProductListView.tsx) / [`SearchBar.tsx`](./../src/frontend/components/SearchBar.tsx) — shop surfaces, route prices through display helpers
+  - [`src/frontend/components/ProductVariationSelector.tsx`](./../src/frontend/components/ProductVariationSelector.tsx) — variation hydration with parent fallback
+  - [`src/frontend/components/ReceiptModal.tsx`](./../src/frontend/components/ReceiptModal.tsx) — receipt rendering
+- Frontend — helpers / types
+  - [`src/frontend/utils/helpers.ts`](./../src/frontend/utils/helpers.ts) — `pickRegularDisplayPrice`, `pickSaleDisplayPrice`, `toFiniteNumber`, `firstPresentNumber`
+  - [`src/frontend/types/index.ts`](./../src/frontend/types/index.ts) — `POSCartItem` (with `raw_*` fields), `Product`, `ProductVariation`, `POSProduct`
+- WooCommerce upstream
+  - `wc_get_price_excluding_tax( $product, [ 'price' => ... ] )`
+  - `wc_get_price_including_tax( $product, [ 'price' => ... ] )`
+  - `WC_REST_Orders_V2_Controller::save_object` — sets `prices_include_tax` flag on saved orders

--- a/includes/REST/Manager.php
+++ b/includes/REST/Manager.php
@@ -65,9 +65,7 @@ class Manager {
         $data           = $response->get_data();
         $type           = isset( $data['type'] ) ? $data['type'] : '';
         $variation_data = [];
-        $tax_display_on_shop = get_option( 'woocommerce_tax_display_shop', 'excl' );
         $tax_display_on_cart = get_option( 'woocommerce_tax_display_cart', 'excl' );
-        $tax_calculations    = get_option( 'woocommerce_prices_include_tax', 'no' );
 
         if ( 'variable' == $type ) {
             foreach( $data['variations'] as $variation ) {
@@ -83,32 +81,29 @@ class Manager {
             }
         }
 
-        $price_excl_tax                = wc_get_price_excluding_tax( $product );
-        $price_incl_tax                = wc_get_price_including_tax( $product );
-        $tax_amount                    = (float)$price_incl_tax - (float)$price_excl_tax;
+        $regular_price = $product->get_regular_price();
+        $sale_price    = $product->get_sale_price();
+        $decimals      = wc_get_price_decimals();
+        $show_incl_tax = 'incl' === $tax_display_on_cart;
 
-        $data['variations']            = [];
+        // Compute tax per-price so sale and regular lines each report their own tax.
+        $regular_excl_tax = (float) wc_get_price_excluding_tax( $product, [ 'price' => $regular_price ] );
+        $regular_incl_tax = (float) wc_get_price_including_tax( $product, [ 'price' => $regular_price ] );
+        $regular_tax      = $regular_incl_tax - $regular_excl_tax;
+
+        // Sale price may be empty when the product is not on sale.
+        $sale_excl_tax = '' === $sale_price ? 0.0 : (float) wc_get_price_excluding_tax( $product, [ 'price' => $sale_price ] );
+        $sale_incl_tax = '' === $sale_price ? 0.0 : (float) wc_get_price_including_tax( $product, [ 'price' => $sale_price ] );
+        $sale_tax      = $sale_incl_tax - $sale_excl_tax;
+
+        $effective_tax   = $product->is_on_sale() ? $sale_tax : $regular_tax;
+        $regular_display = $show_incl_tax ? $regular_excl_tax + $regular_tax : $regular_excl_tax;
+        $sale_display    = $show_incl_tax ? $sale_excl_tax + $sale_tax : $sale_excl_tax;
+
         $data['variations']            = $variation_data;
-        $data['tax_amount']            = wc_format_decimal( $tax_amount, wc_get_price_decimals() );
-
-        if ( 'no' == $tax_calculations ) {
-            if ( 'incl' == $tax_display_on_cart ) {
-                $data['regular_display_price'] = wc_format_decimal( (float)wc_get_price_excluding_tax( $product, [ 'price' => $product->get_regular_price() ] ) + $tax_amount, wc_get_price_decimals() );
-                $data['sales_display_price']   = wc_format_decimal( (float)wc_get_price_excluding_tax( $product, [ 'price' => $product->get_sale_price() ] ) + $tax_amount, wc_get_price_decimals() );
-            } else {
-                $data['regular_display_price'] = wc_format_decimal( (float)wc_get_price_excluding_tax( $product, [ 'price' => $product->get_regular_price() ] ), wc_get_price_decimals() );
-                $data['sales_display_price']   = wc_format_decimal( (float)wc_get_price_excluding_tax( $product, ['price' => $product->get_sale_price() ] ), wc_get_price_decimals() );
-            }
-        } else {
-            if ( 'incl' == $tax_display_on_cart ) {
-                $data['regular_display_price'] = wc_format_decimal( (float)wc_get_price_excluding_tax( $product, [ 'price' => $product->get_regular_price() ] ) + $tax_amount, wc_get_price_decimals() );
-                $data['sales_display_price']   = wc_format_decimal( (float)wc_get_price_excluding_tax( $product, [ 'price' => $product->get_sale_price() ] ) + $tax_amount, wc_get_price_decimals() );
-            } else {
-                $data['regular_display_price'] = wc_format_decimal( (float)wc_get_price_excluding_tax( $product, [ 'price' => $product->get_regular_price() ] ), wc_get_price_decimals() );
-                $data['sales_display_price']   = wc_format_decimal( (float)wc_get_price_excluding_tax( $product, ['price' => $product->get_sale_price() ] ), wc_get_price_decimals() );
-            }
-        }
-
+        $data['tax_amount']            = wc_format_decimal( $effective_tax, $decimals );
+        $data['regular_display_price'] = wc_format_decimal( $regular_display, $decimals );
+        $data['sales_display_price']   = wc_format_decimal( $sale_display, $decimals );
         $data['barcode']               = $product->get_meta( '_wepos_barcode' );
 
         if ( ! empty( $data['images'] ) ) {

--- a/src/frontend/components/Cart.tsx
+++ b/src/frontend/components/Cart.tsx
@@ -304,8 +304,7 @@ const Cart = forwardRef<CartHandle, CartProps>(({
   const cartFormatPrice = (price: number | string): string | number =>
     formatPrice(price, orderCurrencySymbol || '');
 
-  // Read from the cart store (single source of truth) — kept in sync with
-  // `woocommerce_tax_display_cart` by the `setTaxDisplayMode` effect in `Home.tsx`.
+  // Single source of truth: store value, synced from woocommerce_tax_display_cart by Home.tsx.
   const isTaxInclusive = taxDisplayMode === 'incl';
 
   // Count visible columns for colSpan

--- a/src/frontend/components/Cart.tsx
+++ b/src/frontend/components/Cart.tsx
@@ -126,6 +126,7 @@ const Cart = forwardRef<CartHandle, CartProps>(({
     total,
     serverOrder,
     isServerOrderDirty,
+    taxDisplayMode,
   } = useSelect((select) => {
     const store = select(CART_STORE_NAME) as any;
     return {
@@ -146,6 +147,7 @@ const Cart = forwardRef<CartHandle, CartProps>(({
       total: store.getTotal(),
       serverOrder: store.getServerOrder(),
       isServerOrderDirty: store.isServerOrderDirty(),
+      taxDisplayMode: store.getTaxDisplayMode(),
     };
   }, []);
 
@@ -302,7 +304,9 @@ const Cart = forwardRef<CartHandle, CartProps>(({
   const cartFormatPrice = (price: number | string): string | number =>
     formatPrice(price, orderCurrencySymbol || '');
 
-  const isTaxInclusive = settings?.woo_tax?.wc_tax_display_cart === 'incl';
+  // Read from the cart store (single source of truth) — kept in sync with
+  // `woocommerce_tax_display_cart` by the `setTaxDisplayMode` effect in `Home.tsx`.
+  const isTaxInclusive = taxDisplayMode === 'incl';
 
   // Count visible columns for colSpan
   const visibleColumnCount = cartSettings.columns.filter((c) => c.enabled).length || 1;

--- a/src/frontend/components/Cart.tsx
+++ b/src/frontend/components/Cart.tsx
@@ -257,6 +257,8 @@ const Cart = forwardRef<CartHandle, CartProps>(({
       quantity: 1,
       regular_price: product.price,
       sale_price: product.price,
+      raw_regular_price: product.price,
+      raw_sale_price: product.price,
       on_sale: false,
       type: 'simple',
       attribute: [],

--- a/src/frontend/components/ProductGridView.tsx
+++ b/src/frontend/components/ProductGridView.tsx
@@ -12,8 +12,21 @@ import {
   TooltipContent,
 } from '@wedevs/plugin-ui';
 import { POSProduct, CartItem } from '../types';
-import { decodeHtmlEntities } from '../utils/helpers';
+import {
+  decodeHtmlEntities,
+  pickRegularDisplayPrice,
+  pickSaleDisplayPrice,
+} from '../utils/helpers';
 import ProductVariationSelector from './ProductVariationSelector';
+
+// Cart-display price — matches whatever the cart row will render so the cashier
+// sees the same number on both surfaces, regardless of
+// `prices_include_tax` × `tax_display_cart`.
+function getDisplayPrice(product: POSProduct): number {
+  return product.on_sale
+    ? pickSaleDisplayPrice(product)
+    : pickRegularDisplayPrice(product);
+}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -21,16 +34,14 @@ function getVariablePriceRange(
   product: POSProduct,
   formatPrice: (amount: number | string | undefined | null) => string,
 ): string {
-  const fallback = formatPrice(
-    product.on_sale ? product.sale_price : product.regular_price,
-  ) as string;
+  const fallback = formatPrice(getDisplayPrice(product)) as string;
 
   const variations: any[] = product.variations ?? [];
   if (variations.length === 0) return fallback;
 
   const prices = variations
-    .map((v) => parseFloat(v.price || v.regular_price || '0'))
-    .filter((p) => !isNaN(p));
+    .map((v) => (v.on_sale ? pickSaleDisplayPrice(v) : pickRegularDisplayPrice(v)))
+    .filter((p) => p > 0);
 
   if (prices.length === 0) return fallback;
 
@@ -202,11 +213,11 @@ const ProductGridCard: React.FC<ProductGridCardProps> = ({
             <>
               {product.on_sale && product.regular_price && (
                 <span className="mb-0.5 text-xs text-muted-foreground line-through">
-                  {formatPrice(product.regular_price)}
+                  {formatPrice(pickRegularDisplayPrice(product))}
                 </span>
               )}
               <span className="text-sm font-bold text-foreground">
-                {formatPrice(product.on_sale ? product.sale_price : product.regular_price)}
+                {formatPrice(getDisplayPrice(product))}
               </span>
             </>
           )}

--- a/src/frontend/components/ProductGridView.tsx
+++ b/src/frontend/components/ProductGridView.tsx
@@ -19,9 +19,7 @@ import {
 } from '../utils/helpers';
 import ProductVariationSelector from './ProductVariationSelector';
 
-// Cart-display price — matches whatever the cart row will render so the cashier
-// sees the same number on both surfaces, regardless of
-// `prices_include_tax` × `tax_display_cart`.
+// Use the cart-display price so the shop grid matches the cart row across every prices_include_tax × tax_display_cart combo.
 function getDisplayPrice(product: POSProduct): number {
   return product.on_sale
     ? pickSaleDisplayPrice(product)

--- a/src/frontend/components/ProductListView.tsx
+++ b/src/frontend/components/ProductListView.tsx
@@ -10,8 +10,20 @@ import {
   TooltipContent,
 } from '@wedevs/plugin-ui';
 import { POSProduct, CartItem } from '../types';
-import { decodeHtmlEntities } from '../utils/helpers';
+import {
+  decodeHtmlEntities,
+  pickRegularDisplayPrice,
+  pickSaleDisplayPrice,
+} from '../utils/helpers';
 import ProductVariationSelector from './ProductVariationSelector';
+
+// Cart-display price — matches whatever the cart row will render so the cashier
+// sees the same number on both surfaces.
+function getDisplayPrice(product: POSProduct): number {
+  return product.on_sale
+    ? pickSaleDisplayPrice(product)
+    : pickRegularDisplayPrice(product);
+}
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -31,16 +43,14 @@ function getVariablePriceRange(
   product: POSProduct,
   formatPrice: (amount: number | string | undefined | null) => string,
 ): string {
-  const fallback = formatPrice(
-    product.on_sale ? product.sale_price : product.regular_price,
-  ) as string;
+  const fallback = formatPrice(getDisplayPrice(product)) as string;
 
   const variations: any[] = product.variations ?? [];
   if (variations.length === 0) return fallback;
 
   const prices = variations
-    .map((v) => parseFloat(v.price || v.regular_price || '0'))
-    .filter((p) => !isNaN(p));
+    .map((v) => (v.on_sale ? pickSaleDisplayPrice(v) : pickRegularDisplayPrice(v)))
+    .filter((p) => p > 0);
 
   if (prices.length === 0) return fallback;
 
@@ -167,21 +177,19 @@ interface PriceCellProps {
 }
 
 const PriceCell: React.FC<PriceCellProps> = ({ product, formatPrice }) => {
-  const hasRegularPrice =
-    product.on_sale &&
-    product.regular_price &&
-    parseFloat(product.regular_price as string) > 0;
+  const regularDisplay = pickRegularDisplayPrice(product);
+  const hasRegularPrice = product.on_sale && regularDisplay > 0;
 
   const currentPrice =
     product.type === 'variable'
       ? getVariablePriceRange(product, formatPrice)
-      : (formatPrice(product.on_sale ? product.sale_price : product.regular_price) as string);
+      : (formatPrice(getDisplayPrice(product)) as string);
 
   return (
     <div className="flex flex-col items-end gap-0.5">
       {hasRegularPrice && (
         <span className="text-xs text-muted-foreground line-through">
-          {formatPrice(product.regular_price)}
+          {formatPrice(regularDisplay)}
         </span>
       )}
       <span className="text-sm font-bold text-foreground leading-snug">

--- a/src/frontend/components/ProductListView.tsx
+++ b/src/frontend/components/ProductListView.tsx
@@ -17,8 +17,7 @@ import {
 } from '../utils/helpers';
 import ProductVariationSelector from './ProductVariationSelector';
 
-// Cart-display price — matches whatever the cart row will render so the cashier
-// sees the same number on both surfaces.
+// Use the cart-display price so the shop list matches the cart row across every prices_include_tax × tax_display_cart combo.
 function getDisplayPrice(product: POSProduct): number {
   return product.on_sale
     ? pickSaleDisplayPrice(product)

--- a/src/frontend/components/ProductVariationSelector.tsx
+++ b/src/frontend/components/ProductVariationSelector.tsx
@@ -85,6 +85,8 @@ export const ProductVariationSelector: React.FC<
       quantity: 1,
       regular_price: pickDisplayPrice(matchingVariation, 'regular'),
       sale_price: pickDisplayPrice(matchingVariation, 'sale'),
+      raw_regular_price: toFiniteNumber(matchingVariation.regular_price),
+      raw_sale_price: toFiniteNumber(matchingVariation.sale_price),
       on_sale: matchingVariation.on_sale,
       type: 'variable',
       attribute: variationAttributes,

--- a/src/frontend/components/SearchBar.tsx
+++ b/src/frontend/components/SearchBar.tsx
@@ -11,7 +11,7 @@ import {
   DialogFooter,
 } from '@wedevs/plugin-ui';
 import { POSProduct } from '../types';
-import { formatPrice } from '../utils/helpers';
+import { formatPrice, pickRegularDisplayPrice, pickSaleDisplayPrice } from '../utils/helpers';
 import { useBarcodeSettings } from '../hooks/useBarcodeSettings';
 import { useBarcodeScanner } from '../hooks/useBarcodeScanner';
 
@@ -342,7 +342,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ products, settings, onProductAdde
                   >
                     <span className={index === selectedIndex ? 'font-medium text-primary' : 'text-foreground'}>{product.name}</span>
                     <span className="flex items-center gap-3 shrink-0 ml-3">
-                      <span className="font-medium text-foreground">{formatPrice(product.regular_price)}</span>
+                      <span className="font-medium text-foreground">{formatPrice(product.on_sale ? pickSaleDisplayPrice(product) : pickRegularDisplayPrice(product))}</span>
                       {product.sku && <span className="max-w-45 truncate text-xs text-muted-foreground">{product.sku}</span>}
                       <CornerDownLeft className="h-3.5 w-3.5 text-muted-foreground/50" />
                     </span>

--- a/src/frontend/pages/Home.tsx
+++ b/src/frontend/pages/Home.tsx
@@ -345,7 +345,7 @@ const HomePage: React.FC = () => {
     [],
   );
 
-  const { cartItems, total, subtotal, selectedCustomer, feeLines, discountLines, shippingLines, metaData, customerNote, totalShipping, totalFee, totalDiscount, totalTax, serverOrder, orderCurrency, orderCurrencySymbol } = useSelect((select) => {
+  const { cartItems, total, subtotal, selectedCustomer, feeLines, discountLines, shippingLines, metaData, customerNote, totalShipping, totalTax, serverOrder, orderCurrency, orderCurrencySymbol } = useSelect((select) => {
     const cartStore = select(CART_STORE_NAME) as any;
     return {
       cartItems: cartStore.getCartItems(),
@@ -358,8 +358,6 @@ const HomePage: React.FC = () => {
       metaData: cartStore.getMetaData(),
       customerNote: cartStore.getCustomerNote(),
       totalShipping: cartStore.getTotalShipping(),
-      totalFee: cartStore.getTotalFee(),
-      totalDiscount: cartStore.getTotalDiscount(),
       totalTax: cartStore.getTotalTax(),
       serverOrder: cartStore.getServerOrder(),
       orderCurrency: cartStore.getOrderCurrency(),
@@ -807,14 +805,7 @@ const HomePage: React.FC = () => {
         await posAPI.payment.processPayment(orderResponse);
 
       if (paymentResponse.result === 'success') {
-        // Mirror getTotalTax fallback so the printed receipt stays self-consistent when WC reports total_tax=0.
-        const orderTotal = toFiniteNumber(orderResponse.total) || total,
-          serverReportedTax = toFiniteNumber(orderResponse.total_tax),
-          taxGap = orderTotal - (subtotal - totalDiscount + totalFee + totalShipping);
-        const effectiveTax = serverReportedTax > 0
-          ? serverReportedTax
-          : Math.max(0, taxGap > 0.01 ? taxGap : 0);
-
+        // Receipt mirrors cart selectors, so its tax/total carries the same WC-silent fallback — receipt matches the cart row in every prices_include_tax × tax_display_cart combination.
         const printDataToSet = {
           line_items: cartItems.map((cartItem: POSCartItem) => ({
             ...cartItem,
@@ -824,10 +815,10 @@ const HomePage: React.FC = () => {
           coupon_lines: discountLines,
           shipping_lines: shippingLines,
           subtotal: subtotal,
-          taxtotal: effectiveTax,
+          taxtotal: totalTax,
           shippingtotal: totalShipping,
           shippingtaxtotal: toFiniteNumber(orderResponse.shipping_tax),
-          ordertotal: orderTotal,
+          ordertotal: total,
           gateway: {
             id: orderResponse.payment_method,
             title: orderResponse.payment_method_title,

--- a/src/frontend/pages/Home.tsx
+++ b/src/frontend/pages/Home.tsx
@@ -470,6 +470,8 @@ const HomePage: React.FC = () => {
         quantity: 1,
         regular_price: pickDisplayPrice(product, 'regular'),
         sale_price: pickDisplayPrice(product, 'sale'),
+        raw_regular_price: toFiniteNumber(product.regular_price),
+        raw_sale_price: toFiniteNumber(product.sale_price),
         on_sale: product.on_sale,
         type: product.type,
         attribute: [],
@@ -889,7 +891,9 @@ const HomePage: React.FC = () => {
       const matchedServerIds = new Set<number>();
 
       cartItems.forEach((item: POSCartItem) => {
-        const unitPrice = item.on_sale ? item.sale_price : item.regular_price;
+        const rawRegular = item.raw_regular_price ?? item.regular_price;
+        const rawSale = item.raw_sale_price ?? item.sale_price;
+        const unitPrice = item.on_sale ? rawSale : rawRegular;
         const lineItem: any = {
           quantity: item.quantity,
           subtotal: (unitPrice * item.quantity).toFixed(2),
@@ -898,7 +902,7 @@ const HomePage: React.FC = () => {
         if (item.product_id === 0) {
           // Misc/custom product: send name + price, no product_id
           lineItem.name = item.name;
-          lineItem.price = item.regular_price;
+          lineItem.price = unitPrice;
           if (item.sku) {
             lineItem.sku = item.sku;
           }

--- a/src/frontend/pages/Home.tsx
+++ b/src/frontend/pages/Home.tsx
@@ -345,7 +345,7 @@ const HomePage: React.FC = () => {
     [],
   );
 
-  const { cartItems, total, subtotal, selectedCustomer, feeLines, discountLines, shippingLines, metaData, customerNote, totalShipping, totalTax, serverOrder, orderCurrency, orderCurrencySymbol } = useSelect((select) => {
+  const { cartItems, total, subtotal, selectedCustomer, feeLines, discountLines, shippingLines, metaData, customerNote, totalShipping, totalFee, totalDiscount, totalTax, serverOrder, orderCurrency, orderCurrencySymbol } = useSelect((select) => {
     const cartStore = select(CART_STORE_NAME) as any;
     return {
       cartItems: cartStore.getCartItems(),
@@ -358,6 +358,8 @@ const HomePage: React.FC = () => {
       metaData: cartStore.getMetaData(),
       customerNote: cartStore.getCustomerNote(),
       totalShipping: cartStore.getTotalShipping(),
+      totalFee: cartStore.getTotalFee(),
+      totalDiscount: cartStore.getTotalDiscount(),
       totalTax: cartStore.getTotalTax(),
       serverOrder: cartStore.getServerOrder(),
       orderCurrency: cartStore.getOrderCurrency(),
@@ -807,19 +809,33 @@ const HomePage: React.FC = () => {
         await posAPI.payment.processPayment(orderResponse);
 
       if (paymentResponse.result === 'success') {
+        // Receipt tax — same fallback as the `getTotalTax` selector: trust the
+        // server's reported tax when positive; otherwise derive it from the
+        // total/sub gap so the printed receipt is self-consistent even when WC
+        // leaves `total_tax=0` on orders without a resolvable rate location.
+        const orderTotal = toFiniteNumber(orderResponse.total) || total;
+        const serverReportedTax = toFiniteNumber(orderResponse.total_tax);
+        const taxGap = orderTotal - (subtotal - totalDiscount + totalFee + totalShipping);
+        const effectiveTax = serverReportedTax > 0
+          ? serverReportedTax
+          : Math.max(0, taxGap > 0.01 ? taxGap : 0);
+
         const printDataToSet = {
           line_items: cartItems.map((cartItem: POSCartItem) => ({
             ...cartItem,
-            total_tax: 0,
+            // Per-line tax for receipts that show a per-row breakdown.
+            // Pre-fix this was hardcoded to 0, hiding the value even when the
+            // product response carried `tax_amount`.
+            total_tax: toFiniteNumber(cartItem.tax_amount) * cartItem.quantity,
           })),
           fee_lines: feeLines,
           coupon_lines: discountLines,
           shipping_lines: shippingLines,
           subtotal: subtotal,
-          taxtotal: parseFloat(orderResponse.total_tax) || 0,
+          taxtotal: effectiveTax,
           shippingtotal: totalShipping,
-          shippingtaxtotal: parseFloat(orderResponse.shipping_tax) || 0,
-          ordertotal: parseFloat(orderResponse.total) || total,
+          shippingtaxtotal: toFiniteNumber(orderResponse.shipping_tax),
+          ordertotal: orderTotal,
           gateway: {
             id: orderResponse.payment_method,
             title: orderResponse.payment_method_title,

--- a/src/frontend/pages/Home.tsx
+++ b/src/frontend/pages/Home.tsx
@@ -809,13 +809,10 @@ const HomePage: React.FC = () => {
         await posAPI.payment.processPayment(orderResponse);
 
       if (paymentResponse.result === 'success') {
-        // Receipt tax — same fallback as the `getTotalTax` selector: trust the
-        // server's reported tax when positive; otherwise derive it from the
-        // total/sub gap so the printed receipt is self-consistent even when WC
-        // leaves `total_tax=0` on orders without a resolvable rate location.
-        const orderTotal = toFiniteNumber(orderResponse.total) || total;
-        const serverReportedTax = toFiniteNumber(orderResponse.total_tax);
-        const taxGap = orderTotal - (subtotal - totalDiscount + totalFee + totalShipping);
+        // Mirror getTotalTax fallback so the printed receipt stays self-consistent when WC reports total_tax=0.
+        const orderTotal = toFiniteNumber(orderResponse.total) || total,
+          serverReportedTax = toFiniteNumber(orderResponse.total_tax),
+          taxGap = orderTotal - (subtotal - totalDiscount + totalFee + totalShipping);
         const effectiveTax = serverReportedTax > 0
           ? serverReportedTax
           : Math.max(0, taxGap > 0.01 ? taxGap : 0);
@@ -823,9 +820,6 @@ const HomePage: React.FC = () => {
         const printDataToSet = {
           line_items: cartItems.map((cartItem: POSCartItem) => ({
             ...cartItem,
-            // Per-line tax for receipts that show a per-row breakdown.
-            // Pre-fix this was hardcoded to 0, hiding the value even when the
-            // product response carried `tax_amount`.
             total_tax: toFiniteNumber(cartItem.tax_amount) * cartItem.quantity,
           })),
           fee_lines: feeLines,
@@ -910,8 +904,9 @@ const HomePage: React.FC = () => {
       const matchedServerIds = new Set<number>();
 
       cartItems.forEach((item: POSCartItem) => {
-        const rawRegular = item.raw_regular_price ?? item.regular_price;
-        const rawSale = item.raw_sale_price ?? item.sale_price;
+        // Raw prices (stored values) drive the order payload; falls back to display prices for legacy in-memory carts.
+        const rawRegular = item.raw_regular_price ?? item.regular_price,
+          rawSale = item.raw_sale_price ?? item.sale_price;
         const unitPrice = item.on_sale ? rawSale : rawRegular;
         const lineItem: any = {
           quantity: item.quantity,

--- a/src/frontend/pages/Home.tsx
+++ b/src/frontend/pages/Home.tsx
@@ -948,11 +948,12 @@ const HomePage: React.FC = () => {
       const matchedServerIds = new Set<number>();
 
       feeLines.forEach((fee: any, index: number) => {
+        const feeValue = toFiniteNumber(fee.value);
         const feeItem: any = {
           name: fee.name,
           total: fee.fee_type === 'percent'
-            ? ((subtotal * parseFloat(fee.value)) / 100).toFixed(2)
-            : parseFloat(fee.value).toFixed(2),
+            ? ((subtotal * feeValue) / 100).toFixed(2)
+            : feeValue.toFixed(2),
           tax_status: fee.tax_status,
           tax_class: fee.tax_class,
         };

--- a/src/frontend/store/cart/selectors.ts
+++ b/src/frontend/store/cart/selectors.ts
@@ -37,24 +37,28 @@ export const selectors = {
     const subtotal = selectors.getSubtotal(state);
     return state.fee_lines.reduce((total: number, fee: POSFeeLine) => {
       if (fee.fee_type === 'percent') {
-        return total + (subtotal * parseFloat(fee.value)) / 100;
+        return total + (subtotal * toFiniteNumber(fee.value)) / 100;
       } else {
-        return total + parseFloat(fee.value);
+        return total + toFiniteNumber(fee.value);
       }
     }, 0);
   },
 
   getTotalShipping: (state: CartState): number => {
     return state.shipping_lines.reduce((total: number, shipping: POSShippingLine) => {
-      return total + parseFloat(shipping.total || '0');
+      return total + toFiniteNumber(shipping.total);
     }, 0);
   },
 
+  getTaxDisplayMode: (state: CartState): 'incl' | 'excl' =>
+    state.tax_display_cart === 'incl' ? 'incl' : 'excl',
+
   // Raw line-item tax — NOT zeroed in `incl` mode. Drives the "Including Tax" UI hint.
+  // `tax_amount` is `wc_get_price_including_tax - wc_get_price_excluding_tax`, always
+  // non-negative for positive prices, so no `Math.abs` is needed.
   getTotalLineTax: (state: CartState): number => {
     return state.line_items.reduce((total: number, item: POSCartItem) => {
-      const perUnitTax = toFiniteNumber(item.tax_amount);
-      return total + Math.abs(perUnitTax * item.quantity);
+      return total + toFiniteNumber(item.tax_amount) * item.quantity;
     }, 0);
   },
 
@@ -79,9 +83,9 @@ export const selectors = {
       const rate = findRate(fee.tax_class);
       if (!rate) return sum;
       const feeAmount = fee.fee_type === 'percent'
-        ? (subtotal * parseFloat(fee.value)) / 100
-        : parseFloat(fee.value);
-      return sum + (Math.abs(feeAmount) * Math.abs(rate)) / 100;
+        ? (subtotal * toFiniteNumber(fee.value)) / 100
+        : toFiniteNumber(fee.value);
+      return sum + (feeAmount * rate) / 100;
     }, 0);
 
     // Sign flips vs. legacy Vue (stored coupon.total negative); here discountAmount is positive.
@@ -95,10 +99,12 @@ export const selectors = {
       return sum + (discountAmount / subtotal) * lineTax;
     }, 0);
 
+    // Filter payload exposes derived totals only — never the live store state — so
+    // a misbehaving extension cannot mutate cart internals from inside the filter.
     return applyFilters<number>(
       'wepos_cart_total_tax',
       lineTax + feeTax - couponTaxReduction,
-      { state, lineTax, feeTax, couponTaxReduction }
+      { lineTax, feeTax, couponTaxReduction }
     );
   },
 
@@ -134,9 +140,9 @@ export const selectors = {
   getFeeAmount: (state: CartState, fee: POSFeeLine): number => {
     const subtotal = selectors.getSubtotal(state);
     if (fee.fee_type === 'percent') {
-      return (subtotal * parseFloat(fee.value)) / 100;
+      return (subtotal * toFiniteNumber(fee.value)) / 100;
     } else {
-      return parseFloat(fee.value);
+      return toFiniteNumber(fee.value);
     }
   },
 };

--- a/src/frontend/store/cart/selectors.ts
+++ b/src/frontend/store/cart/selectors.ts
@@ -61,21 +61,23 @@ export const selectors = {
   },
 
   getTotalTax: (state: CartState): number => {
+    // Resolution order: 1) WC's authoritative server tax  2) tax bundled into server.total (gap)  3) legacy local formula.
     if (state.server_order && !state.server_order_dirty) {
       const serverTax = toFiniteNumber(state.server_order.total_tax);
       if (serverTax > 0) return serverTax;
 
-      // Fallback when WC silently reports total_tax=0 (e.g. unresolvable rate location): derive tax from total − non-tax components so Subtotal + Tax = Order Total.
-      const subtotalForGap = selectors.getSubtotal(state),
-        discountForGap = selectors.getTotalDiscount(state),
-        feeForGap = selectors.getTotalFee(state),
-        shippingForGap = selectors.getTotalShipping(state),
-        serverTotal = toFiniteNumber(state.server_order.total);
-      const gap = serverTotal - (subtotalForGap - discountForGap + feeForGap + shippingForGap);
-      return gap > 0.01 ? gap : 0;
+      // WC silently reports 0 when it cannot resolve a rate (e.g. guest order, no shop base country); recover bundled tax from total − non-tax.
+      const nonTax = selectors.getSubtotal(state)
+        - selectors.getTotalDiscount(state)
+        + selectors.getTotalFee(state)
+        + selectors.getTotalShipping(state);
+      const gap = toFiniteNumber(state.server_order.total) - nonTax;
+      if (gap > 0.01) return gap;
+
+      // No bundled tax — fall through. Excl mode then recovers per-line tax_amount; incl mode returns just feeTax (lineTax is zeroed below to avoid double-counting).
     }
 
-    // `incl` mode: line price already includes tax; fees and coupons still apply.
+    // Legacy local formula (port of Cart.module.js#getTotalTax lines 52–102) — also acts as the post-save fall-through above.
     const lineTax = state.tax_display_cart === 'incl' ? 0 : selectors.getTotalLineTax(state);
     const subtotal = selectors.getSubtotal(state);
 
@@ -116,17 +118,25 @@ export const selectors = {
   },
 
   getTotal: (state: CartState): number => {
+    // Always derive `computed` so the cart's "subtotal + tax = total" invariant survives a WC-silent saved order.
+    const computed = Math.max(
+      0,
+      selectors.getSubtotal(state)
+        - selectors.getTotalDiscount(state)
+        + selectors.getTotalFee(state)
+        + selectors.getTotalShipping(state)
+        + selectors.getTotalTax(state),
+    );
+
     if (state.server_order && !state.server_order_dirty) {
-      return toFiniteNumber(state.server_order.total);
+      const serverTotal = toFiniteNumber(state.server_order.total);
+      // serverTax > 0 ⇒ WC resolved the rate; its total is authoritative.
+      if (toFiniteNumber(state.server_order.total_tax) > 0) return serverTotal;
+      // Side-effect: when WC under-reported tax, returned total may exceed the DB-saved server_order.total — display-layer recovery only; accounting reports must still read server_order.total directly.
+      return Math.max(serverTotal, computed);
     }
 
-    const subtotal = selectors.getSubtotal(state);
-    const totalDiscount = selectors.getTotalDiscount(state);
-    const totalFee = selectors.getTotalFee(state);
-    const totalShipping = selectors.getTotalShipping(state);
-    const totalTax = selectors.getTotalTax(state);
-
-    return Math.max(0, subtotal - totalDiscount + totalFee + totalShipping + totalTax);
+    return computed;
   },
 
   getOrderCurrency: (state: CartState): string => state.currency,

--- a/src/frontend/store/cart/selectors.ts
+++ b/src/frontend/store/cart/selectors.ts
@@ -53,9 +53,7 @@ export const selectors = {
   getTaxDisplayMode: (state: CartState): 'incl' | 'excl' =>
     state.tax_display_cart === 'incl' ? 'incl' : 'excl',
 
-  // Raw line-item tax — NOT zeroed in `incl` mode. Drives the "Including Tax" UI hint.
-  // `tax_amount` is `wc_get_price_including_tax - wc_get_price_excluding_tax`, always
-  // non-negative for positive prices, so no `Math.abs` is needed.
+  // Drives the "Including Tax" UI hint — never zeroed in incl mode.
   getTotalLineTax: (state: CartState): number => {
     return state.line_items.reduce((total: number, item: POSCartItem) => {
       return total + toFiniteNumber(item.tax_amount) * item.quantity;
@@ -67,17 +65,12 @@ export const selectors = {
       const serverTax = toFiniteNumber(state.server_order.total_tax);
       if (serverTax > 0) return serverTax;
 
-      // Server explicitly reported zero tax. WC sometimes leaves `total_tax=0`
-      // on pos-open orders when it can't resolve a tax rate from the order
-      // location (e.g. guest with no billing address). The line totals already
-      // bundle the tax in that case, so derive the tax from the gap between
-      // `server.total` and the sum of non-tax components. Keeps the summary
-      // self-consistent: Subtotal + Tax = Order Total.
-      const subtotalForGap = selectors.getSubtotal(state);
-      const discountForGap = selectors.getTotalDiscount(state);
-      const feeForGap = selectors.getTotalFee(state);
-      const shippingForGap = selectors.getTotalShipping(state);
-      const serverTotal = toFiniteNumber(state.server_order.total);
+      // Fallback when WC silently reports total_tax=0 (e.g. unresolvable rate location): derive tax from total − non-tax components so Subtotal + Tax = Order Total.
+      const subtotalForGap = selectors.getSubtotal(state),
+        discountForGap = selectors.getTotalDiscount(state),
+        feeForGap = selectors.getTotalFee(state),
+        shippingForGap = selectors.getTotalShipping(state),
+        serverTotal = toFiniteNumber(state.server_order.total);
       const gap = serverTotal - (subtotalForGap - discountForGap + feeForGap + shippingForGap);
       return gap > 0.01 ? gap : 0;
     }
@@ -114,8 +107,7 @@ export const selectors = {
       return sum + (discountAmount / subtotal) * lineTax;
     }, 0);
 
-    // Filter payload exposes derived totals only — never the live store state — so
-    // a misbehaving extension cannot mutate cart internals from inside the filter.
+    // Filter payload exposes derived totals only — never the live store — so callbacks can't mutate cart state.
     return applyFilters<number>(
       'wepos_cart_total_tax',
       lineTax + feeTax - couponTaxReduction,

--- a/src/frontend/store/cart/selectors.ts
+++ b/src/frontend/store/cart/selectors.ts
@@ -64,7 +64,22 @@ export const selectors = {
 
   getTotalTax: (state: CartState): number => {
     if (state.server_order && !state.server_order_dirty) {
-      return toFiniteNumber(state.server_order.total_tax);
+      const serverTax = toFiniteNumber(state.server_order.total_tax);
+      if (serverTax > 0) return serverTax;
+
+      // Server explicitly reported zero tax. WC sometimes leaves `total_tax=0`
+      // on pos-open orders when it can't resolve a tax rate from the order
+      // location (e.g. guest with no billing address). The line totals already
+      // bundle the tax in that case, so derive the tax from the gap between
+      // `server.total` and the sum of non-tax components. Keeps the summary
+      // self-consistent: Subtotal + Tax = Order Total.
+      const subtotalForGap = selectors.getSubtotal(state);
+      const discountForGap = selectors.getTotalDiscount(state);
+      const feeForGap = selectors.getTotalFee(state);
+      const shippingForGap = selectors.getTotalShipping(state);
+      const serverTotal = toFiniteNumber(state.server_order.total);
+      const gap = serverTotal - (subtotalForGap - discountForGap + feeForGap + shippingForGap);
+      return gap > 0.01 ? gap : 0;
     }
 
     // `incl` mode: line price already includes tax; fees and coupons still apply.

--- a/src/frontend/types/index.ts
+++ b/src/frontend/types/index.ts
@@ -186,6 +186,8 @@ export interface POSCartItem {
   on_sale: boolean;
   sale_price: number;
   regular_price: number;
+  raw_regular_price?: number;
+  raw_sale_price?: number;
   editQuantity?: boolean;
   attribute: Array<{
     id?: number;


### PR DESCRIPTION
Closes: [wePOS incorrectly calculates/adds Tax/VAT during checkout](https://github.com/getdokan/wepos-pro/issues/139)

## Summary

Fixes wePOS tax/VAT calculation so the order total saved on the server matches what the cashier sees in the cart, and corrects the per-row tax label on sale-priced products.

## What was wrong

WooCommerce has two related-but-independent settings:

- **`woocommerce_prices_include_tax`** ("Prices entered with tax") — declares whether the stored `regular_price` / `sale_price` on every product is tax-inclusive or tax-exclusive. **This is the contract for the order REST API.**
- **`woocommerce_tax_display_cart`** — a display-only setting: "show prices in cart inclusive or exclusive?" Independent of how prices are stored.

In `WC_REST_Orders_V2_Controller::save_object`, the order is flagged via `$object->set_prices_include_tax( 'yes' === get_option('woocommerce_prices_include_tax') )` and then `calculate_totals()` runs. WC interprets each posted `total` / `subtotal` under that flag.

The recent React port computed a "display price" server-side (`regular_display_price` / `sales_display_price`) so the cart UI could render the right number per `tax_display_cart`. Those display prices replaced the cart item's `regular_price` / `sale_price` (`Home.tsx:471-472`) and `buildOrderPayload` then posted them as the line item `total` / `subtotal` (`Home.tsx:891-897`).

When `tax_display_cart` and `prices_include_tax` agree, this is fine. When they disagree, the server re-interprets the posted number under the wrong tax mode → **double tax** or **wrong base**.

A secondary defect in `Manager.php`: `tax_amount` was derived from `$product->get_price()` (the sale price when on sale), then that sale-derived tax was added to the regular-price base when building `regular_display_price`. For a $100 product on sale at $80 with 10% tax this produced `regular_display_price = $108` instead of $110, and reported $8 per-unit tax where the regular line should report $10.

## What changed

- **`includes/REST/Manager.php`** — `product_response()` now computes tax independently for the regular and sale prices, uses the right one for each output, and handles the empty-sale-price case cleanly. The legacy duplicate `if/else` on `prices_include_tax` (both arms textually identical) was collapsed.
- **`src/frontend/types/index.ts`** — `POSCartItem` gains two optional fields: `raw_regular_price` and `raw_sale_price`. The existing `regular_price` / `sale_price` remain the display values and continue to drive the cart UI.
- **`src/frontend/pages/Home.tsx`** — Cart hydration populates `raw_*` from the product's stored prices. `buildOrderPayload` uses `raw_*` for `line_items[].total` / `subtotal` (and the misc-product `price`), so the values posted to the server match `woocommerce_prices_include_tax`. Falls back to the display price for legacy in-memory carts.
- **`src/frontend/components/ProductVariationSelector.tsx`** — Variations populate `raw_*` from `matchingVariation.regular_price` / `.sale_price`.
- **`src/frontend/components/Cart.tsx`** — Misc/custom products set `raw_*` equal to the cashier-entered price (WC interprets that single value per its `prices_include_tax` setting).

## Why the fix is correct

The contract for the order REST API is the merchant's stored price (matches `prices_include_tax`). The display layer is independent. The bug conflated the two by routing the display price through the order payload.

The fix separates them on the cart item:
- `regular_price` / `sale_price` continue to be display values (drive the UI subtotal).
- New `raw_regular_price` / `raw_sale_price` are the unmodified WC-stored values (drive the order payload).

The cart UI math is unchanged, the cashier sees the same numbers, and `WC_REST_Orders_V2_Controller::save_object → calculate_totals()` now operates on a value it interprets the same way as the merchant who set up the store.

For sale-priced products, computing tax per price (rather than reusing the effective-price tax for both lines) makes the regular and sale rows each report their own correct tax — fixing the $108 vs $110 discrepancy.

---

## How to test

### Setup

1. **WooCommerce → Settings → Tax → Tax options**
   - "Prices entered with tax" — try both `Yes (inclusive)` and `No (exclusive)`.
   - "Display prices in the cart and checkout" — try both `Including tax` and `Excluding tax`.
2. Add a tax rate (e.g. 10%) under **Tax → Standard rates**.
3. Have one product priced `$100` (regular only) and another with `regular=$100, sale=$80`.

### The four critical permutations

For each combo of (`prices_include_tax` × `tax_display_cart`), add the $100 regular product, place the order, then compare the cart total vs. the saved order total in `WooCommerce → Orders`.

| `prices_include_tax` | `tax_display_cart` | Before fix | After fix |
|---|---|---|---|
| no | excl | \$100 + \$10 = \$110 ✅ | \$110 ✅ |
| no | **incl** | cart shows \$110; order saves as \$110 + \$11 = **\$121** ❌ | cart shows \$110; order saves \$110 ✅ |
| yes | **excl** | cart shows \$90.91; order saves with wrong base (\$82.65 net) ❌ | cart shows \$90.91; order saves \$100 ✅ |
| yes | incl | \$100 ✅ | \$100 ✅ |

The two middle rows are where the bug bites. Pre-fix, the cart total and order total disagree. Post-fix, they match.

### Sale-product test (Manager.php secondary fix)

Use `regular=$100, sale=$80, 10% tax, prices_include_tax=no, tax_display_cart=incl`.

| Field on the cart row | Before fix | After fix |
|---|---|---|
| `regular_display_price` | \$108 | \$110 |
| `sales_display_price` | \$88 | \$88 |
| Per-row tax shown | \$8 | \$10 (regular) / \$8 (on sale) |

In the wePOS UI, the strikethrough regular price should now read **\$110** instead of \$108.

### Quick smoke

- [ ] Add a regular product, a sale product, and a variation. Verify each row's tax label matches manual calculation.
- [ ] Place orders in all four tax-setting combos. Each saved order total in `wp-admin → Orders` must equal what the cashier saw.
- [ ] Add a misc/custom product ("Add custom item") at $50. Verify the order total = $50 (excl-tax store + excl display) or $50 final-incl (inclusive store).

---

## Worked example

**Setting:** `prices_include_tax = no`, `tax_display_cart = incl`, product = $100, tax = 10%.

### Before fix

| Step | Value |
|---|---|
| Server `regular_display_price` | \$110 (WC adds 10% on top for display) |
| Cart UI shows | \$110 |
| `buildOrderPayload.total` sent to server | \$110 (display value) |
| Server flags order with `set_prices_include_tax('no')` because `woocommerce_prices_include_tax = no` | — |
| Server treats \$110 as tax-exclusive net | — |
| Server adds 10% on top | \$110 + \$11 = **\$121** |
| Cashier saw \$110, order saved as \$121 | ❌ mismatch |

### After fix

| Step | Value |
|---|---|
| Cart item now stores `raw_regular_price = $100` (from `product.regular_price`) | — |
| Cart UI still shows | \$110 (uses `regular_price` / display) |
| `buildOrderPayload.total` sent to server | \$100 (raw value) |
| Server treats \$100 as tax-exclusive net | — |
| Server adds 10% on top | \$100 + \$10 = **\$110** |
| Cashier saw \$110, order saved as \$110 | ✅ match |

The display layer is unchanged. The order-payload layer now sends the price in the unit WC expects.

---

## Risk / blast radius

- **Display layer:** unchanged. Cart UI, receipt, and product list still read `regular_price` / `sale_price` (display values) and `regular_display_price` / `sales_display_price`.
- **Order payload:** changes per the table above. Stores where `prices_include_tax` and `tax_display_cart` already agreed (both excl, or both incl) see no behavioural change. Stores where they disagreed will start saving correct totals — this is the intended fix, but reports/dashboards that aggregated the previously-wrong totals will see a step change.
- **Backwards compatibility:** `raw_*` fields are optional on `POSCartItem`. `buildOrderPayload` falls back to `regular_price` / `sale_price` when `raw_*` is absent, so any in-memory carts hydrated before this build keep working.
- **No DB migration, no settings change, no admin UI change.**

## Verification

- `php -l includes/REST/Manager.php` — clean.
- `npm run build` — succeeds.
- `tsc --noEmit` — all reported errors are pre-existing in unrelated files; none in the changed regions.