### PR TITLE
chore: rename plugin to include Dokan in name

### DIFF
--- a/.github/workflows/e2e_api_tests.yml
+++ b/.github/workflows/e2e_api_tests.yml
@@ -69,6 +69,11 @@ jobs:
         id: clone-wepos-lite
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
       - name: Use desired version of NodeJS
         uses: actions/setup-node@v4
         with:
@@ -80,11 +85,6 @@ jobs:
         with:
           php-version: '7.4'
           tools: composer:v1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
 
       - name: Install dependencies and build (Wepos-lite)
         run: |

--- a/.github/workflows/e2e_api_tests.yml
+++ b/.github/workflows/e2e_api_tests.yml
@@ -78,7 +78,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
 
       - name: Setup PHP with tools
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/e2e_api_tests.yml
+++ b/.github/workflows/e2e_api_tests.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Use desired version of NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Setup PHP with tools
         uses: shivammathur/setup-php@v2

--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,4 @@ composer.lock
 
 # Zip files
 *.zip
+.vscode

--- a/languages/wepos.pot
+++ b/languages/wepos.pot
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 weDevs. All Rights Reserved.
 msgid ""
 msgstr ""
-"Project-Id-Version: wePOS - Point Of Sale (POS) for WooCommerce 2.0.1\n"
+"Project-Id-Version: wePOS - Point Of Sale (POS) for WooCommerce & Dokan 2.0.1\n"
 "Report-Msgid-Bugs-To: https://wedevs.com/\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,7 +15,7 @@ msgstr ""
 
 #. Plugin Name of the plugin
 #: wepos.php
-msgid "wePOS - Point Of Sale (POS) for WooCommerce"
+msgid "wePOS - Point Of Sale (POS) for WooCommerce & Dokan"
 msgstr ""
 
 #. Plugin URI of the plugin

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   "engines": {
     "node": ">=18"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@wedevs/plugin-ui"
+    ]
+  },
   "scripts": {
     "start": "NODE_ENV=development wp-scripts start --hot",
     "build": "wp-scripts build",

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== wePOS - Point Of Sale (POS) for WooCommerce ===
+=== wePOS - Point Of Sale (POS) for WooCommerce & Dokan ===
 Contributors: tareq1988, wedevs, nizamuddinbabu
 Donate Link: http://tareq.co/donate/
 Tags: pos, point-of-sale, pos plugin, WooCommerce POS, free Pos

--- a/wepos.php
+++ b/wepos.php
@@ -1,8 +1,8 @@
 <?php
 /*
-Plugin Name: wePOS - Point Of Sale (POS) for WooCommerce
+Plugin Name: wePOS - Point Of Sale (POS) for WooCommerce & Dokan
 Plugin URI: https://wedevs.com/wepos
-Description: A beautiful and fast Point of Sale (POS) system for WooCommerce
+Description: A beautiful and fast Point of Sale (POS) system for WooCommerce & Dokan
 Version: 2.0.1
 Author: weDevs
 Author URI: https://wedevs.com/


### PR DESCRIPTION
## Summary
Rename plugin to **wePOS - Point Of Sale (POS) for WooCommerce & Dokan** and fix a chain of pre-existing CI breakages in the E2E/API workflow (red on `develop` for days — none caused by the rename).

### Rename
- `wepos.php` — Plugin Name + Description (mention Dokan)
- `readme.txt` — title heading
- `languages/wepos.pot` — Project-Id-Version + Plugin Name msgid
- `.gitignore` — ignore `.vscode`

### CI fixes (`.github/workflows/e2e_api_tests.yml`, `package.json`)
1. **Install pnpm before setup-node** — setup-node needed pnpm on PATH to compute the cache key (`Unable to locate executable file: pnpm`).
2. **Drop `cache: pnpm`** — `pnpm-lock.yaml` is gitignored, so there is no lockfile to key on (`Dependencies lock file is not found`).
3. **Allowlist `@wedevs/plugin-ui` in `pnpm.onlyBuiltDependencies`** — pnpm 10 blocks build scripts for git-hosted deps unless allowlisted (`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`).
4. **Build under node 22** — `@wedevs/plugin-ui` is a git dep built from source on install; it declares `engines.node >=22` (`.nvmrc` 24) and its wp-scripts/babel toolchain fails to transpile TS under node 20 (`ERR_PNPM_PREPARE_PACKAGE: Module parse failed`). Verified the git-dep build succeeds on node 22.

## Test plan
- [ ] E2E/API workflow installs + builds (plugin-ui git-dep build passes)
- [ ] Plugin name displays correctly in WP admin Plugins list